### PR TITLE
Fix IOS paste on context menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## OTP Input for React
+## [OTP Input for React](https://input-otp.rodz.dev)
 
 https://github.com/guilhermerodz/input-otp/assets/10366880/7de9c10f-d7aa-48e8-93bc-c2cf0e3dfd49
 
@@ -137,3 +137,7 @@ Additional props:
 `onComplete`: Attach a function to execute after the input value reaches its max length.
 
 `value`: For controlled inputs (like _react-hook-form_).
+
+## Website
+
+https://input-otp.rodz.dev

--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
-# OTP Input for React
+## OTP Input for React
 
-Still writing docs/examples...
+https://github.com/guilhermerodz/input-otp/assets/10366880/7de9c10f-d7aa-48e8-93bc-c2cf0e3dfd49
 
-## Installation
+One time passcode Input. Accessible & unstyled.
 
-`npm install input-otp`
+_Still writing docs/examples..._
+
+## Usage
+
+```bash
+npm install input-otp
+```
+
+Import the `<OTPInput />`, create your `<Slot {...slot} />` component and perhaps a `<FakeCaret />`
 
 ## Default example
 
@@ -101,3 +109,31 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 ```
+
+## API Reference
+
+### OTPInput
+
+The input root itself. It's works as a _container div_ that renders 1. your custom `<Slot {...slot} />` component and 2. a hidden native input (opacity 0). The underlying invisible input makes it accessible as the user only execute actions on it, not the container.
+
+Mandatory props:
+
+`maxLength`: Number of slots.
+`render`: A JSX component for rendering slots. Receive the props:
+  - `slots`: `Slot[]` being `type Slot = { isActive: boolean, char: string | null, hasFakeCaret: boolean }`
+  - `isFocused`: Is the native input focused?
+  - `isHovering`: Is the user hovering the root container?
+
+Additional props:
+
+`allowNavigation`: Default `true`. When `false`, the input will prevent keyboard navigation (like arrows) and multi-range (2+ chars) selections.
+
+`inputMode`: Default `numeric`. When `text`, the component will set it's internal native HTML input attribute "inputMode".
+
+`onBlur`: Attach a function when the input triggers `blur` event.
+
+`onChange`: For controlled inputs (like _react-hook-form_).
+
+`onComplete`: Attach a function to execute after the input value reaches its max length.
+
+`value`: For controlled inputs (like _react-hook-form_).

--- a/website/src/app/(pages)/(home)/_components/showcase.tsx
+++ b/website/src/app/(pages)/(home)/_components/showcase.tsx
@@ -12,7 +12,7 @@ import { cn } from '@/lib/utils'
 // )
 
 export function Showcase({ className, ...props }: { className?: string }) {
-  const [value, setValue] = React.useState('12')
+  const [value, setValue] = React.useState('')
   const [disabled, setDisabled] = React.useState(true)
 
   const [preloadConfetti, setPreloadConfetti] = React.useState(0)
@@ -95,11 +95,12 @@ export function Showcase({ className, ...props }: { className?: string }) {
           onChange={setValue}
           containerClassName={cn('group flex items-center')}
           maxLength={6}
+          id="otp-input" // temporary styling
           allowNavigation={true}
           pattern={REGEXP_ONLY_DIGITS}
           render={({ slots, isFocused }) => (
             <>
-              <div className="flex">
+              <div className="flex pointer-events-none">
                 {slots.slice(0, 3).map((slot, idx) => (
                   <Slot
                     key={idx}
@@ -140,10 +141,11 @@ function Slot(props: {
   return (
     <div
       className={cn(
-        'relative w-10 md:w-20 h-14 md:h-28 text-[2rem] md:text-[4rem] flex items-center justify-center border-border border-y border-r first:border-l first:rounded-l-md last:rounded-r-md transition-all [transition-duration:300ms] outline outline-0 outline-accent-foreground/20',
+        'relative pointer-events-none w-10 md:w-20 h-14 md:h-28 text-[2rem] md:text-[4rem] flex items-center justify-center border-border border-y border-r first:border-l first:rounded-l-md last:rounded-r-md transition-all [transition-duration:300ms] outline outline-0 outline-accent-foreground/20',
         'group-hover:border-accent-foreground/20 group-focus-within:border-accent-foreground/20',
         {
-          'outline-4 outline-accent-foreground z-10': props.isActive,
+          'outline-4 outline-accent-foreground z-10 pointer-events-none':
+            props.isActive,
         },
       )}
     >

--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -82,3 +82,8 @@
     transform: translateY(-100%);
   }
 }
+
+/* This styling should probably be in the library itself. */
+#otp-input::selection {
+  background-color: transparent;
+}


### PR DESCRIPTION
This solution is still in exploration, and consists in two steps:

1- having the input element always reachable, but with invisible characters, cursor, etc.
2- having a ghost character that will allow ios to show the "paste" button when long pressing the input element before inputing any value


#### About the ghost character

Just by having the first item of this PR will allow the input to be copy/pastable in mobile devices, however, a long press action on the input will only show the "paste" option if:

1- the input is already focused.
2- the input already has some content in it.

since we can't guarantee that the input will always be focused before the user interacts with it, *IF* we want to not have the necessity of having the input focused before showing the "paste" option, a existence of a ghost character can solve this problem.

I would personally like to not have to fallback in this kind of solution since it will add more complexity when handling the input selection range, the value attached to input, the input on change event, and copying (as we can see on the files changed at time of write)

anyways, here's a solution that seems to bring a nice UX to the end user: