### PR TITLE
feat(input): provide container props

### DIFF
--- a/packages/input-otp/src/input.tsx
+++ b/packages/input-otp/src/input.tsx
@@ -17,7 +17,7 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
       inputMode = 'numeric',
       onComplete,
       render,
-      containerClassName,
+      containerProps,
       ...props
     },
     ref,
@@ -522,8 +522,7 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
       <div
         data-input-otp-container
         style={rootStyle}
-        {...props}
-        className={containerClassName}
+        {...containerProps}
         ref={ref}
       >
         {renderedChildren}

--- a/packages/input-otp/src/types.ts
+++ b/packages/input-otp/src/types.ts
@@ -9,6 +9,7 @@ export interface RenderProps {
   isHovering: boolean
 }
 type OverrideProps<T, R> = Omit<T, keyof R> & R
+type OTPContainerProps = React.ComponentPropsWithoutRef<'div'>
 export type OTPInputProps = OverrideProps<
   React.InputHTMLAttributes<HTMLInputElement>,
   {
@@ -24,7 +25,7 @@ export type OTPInputProps = OverrideProps<
 
     render: (props: RenderProps) => React.ReactElement
 
-    containerClassName?: string
+    containerProps?: OTPContainerProps
   }
 >
 export enum SelectionType {


### PR DESCRIPTION
# Motivation:

When I used the [shadcn form Input OTP example](https://ui.shadcn.com/docs/components/input-otp#form), I noticed that the input did not receive focus when clicking on the label because the id was a property passed on to both the container and the input itself. So I created a new optional prop called `containerProps`. I believe this is a breaking change due to the removal of the old `containerClassName` property.

![shadcn Input OTP form example](https://github.com/guilhermerodz/input-otp/assets/68625746/14aa905b-b829-49ea-a774-7b62ae40f6c6)
