### PR TITLE
docs: Update example for auto submit to prevent page refreshes

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ export default function Page() {
     <form ref={formRef}>
       <OTPInput
         // ... automatically submit the form
-        onComplete={() => formRef.current?.submit()}
+        onComplete={() => formRef.current?.requestSubmit()}
         // ... or focus the button like as you wish
         onComplete={() => buttonRef.current?.focus()}
       />


### PR DESCRIPTION
Currently, the example shown for auto form submission can cause the page to reload as the form `onsubmit` handler isn't called by `form.submit` [see MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit). To call the form `onsubmit` you need to use `form.requestSubmit`