### PR TITLE
fix: set a fallback value for `--root-height` to prevent page zoom

### DIFF
--- a/packages/input-otp/src/input.tsx
+++ b/packages/input-otp/src/input.tsx
@@ -383,7 +383,7 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
         boxShadow: 'none',
         lineHeight: '1',
         letterSpacing: '-.5em',
-        fontSize: 'var(--root-height)',
+        fontSize: 'var(--root-height, 16px)',
         fontFamily: 'monospace',
         fontVariantNumeric: 'tabular-nums',
         // letterSpacing: '-1em',


### PR DESCRIPTION
As title.

See demo below. This is due to, if input's font size is smaller than 16px, for accessibility reasons, iOS will zoom page to enlarge input. So we give a fallback font size with 16px for `--root-height` which input will use as its font size if `--root-height` is not available yet.

Without fix:

https://github.com/user-attachments/assets/d597416a-f018-45b1-84a8-e24a4670c0b6

With fix:

https://github.com/user-attachments/assets/0b251186-1cbc-46ec-92c0-87591893b541

