### PR TITLE
feat: add csp nonce prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,10 @@ type OTPInputProps = {
   //   }
   // }`
   noScriptCSSFallback?: string | null
+
+  // If you are using a Content-Security-Policy (CSP) with the `style-src` directive, you may need to 
+  // specify a nonce value for the inline style tag.
+  nonce?: string
 }
 ```
 

--- a/packages/input-otp/src/input.tsx
+++ b/packages/input-otp/src/input.tsx
@@ -26,6 +26,7 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
       pasteTransformer,
       containerClassName,
       noScriptCSSFallback = NOSCRIPT_CSS_FALLBACK,
+      nonce,
 
       render,
       children,
@@ -173,6 +174,7 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
       if (!document.getElementById('input-otp-style')) {
         const styleEl = document.createElement('style')
         styleEl.id = 'input-otp-style'
+        if (nonce) styleEl.setAttribute('nonce', nonce)
         document.head.appendChild(styleEl)
 
         if (styleEl.sheet) {

--- a/packages/input-otp/src/types.ts
+++ b/packages/input-otp/src/types.ts
@@ -27,6 +27,8 @@ type OTPInputBaseProps = OverrideProps<
     containerClassName?: string
 
     noScriptCSSFallback?: string | null
+
+    nonce?: string
   }
 >
 type InputOTPRenderFn = (props: RenderProps) => React.ReactNode


### PR DESCRIPTION
resolves #48 

Specify a nonce so that the inline style tag can be applied in pages that use a Content-Security-Policy (CSP).

We could attempt to infer this from `document.currentScript.nonce`, but the style nonce can technically be different from the script nonce, and it's not always inheritable (from testing, this wasn't inheritable in NextJS). 

I also didn't want to affect existing behaviour if it's not necessary.
