### PR TITLE
fix(website): improve OTP slot border animation smoothness

### DIFF
--- a/apps/website/src/app/(pages)/(home)/_components/showcase.tsx
+++ b/apps/website/src/app/(pages)/(home)/_components/showcase.tsx
@@ -22,7 +22,7 @@ export function Showcase({ className, ...props }: { className?: string }) {
 
   React.useEffect(() => {
     const isMobile = window.matchMedia('(max-width: 1023px)').matches
-    if (!isMobile)  {
+    if (!isMobile) {
       setDisabled(true)
     }
     const t1 = setTimeout(() => {
@@ -87,10 +87,16 @@ export function Showcase({ className, ...props }: { className?: string }) {
       )}
       {hasGuessed && (
         <div className="fixed inset-0 z-50 pointer-events-none motion-reduce:hidden">
-          <DynamicConfetti pageCoords={{
-            x: inputRef.current!.getBoundingClientRect().left + (inputRef.current?.getBoundingClientRect().width || 0) * 0.9,
-            y: inputRef.current!.getBoundingClientRect().top + (inputRef.current?.getBoundingClientRect().height || 0) / 2
-          }} />
+          <DynamicConfetti
+            pageCoords={{
+              x:
+                inputRef.current!.getBoundingClientRect().left +
+                (inputRef.current?.getBoundingClientRect().width || 0) * 0.9,
+              y:
+                inputRef.current!.getBoundingClientRect().top +
+                (inputRef.current?.getBoundingClientRect().height || 0) / 2,
+            }}
+          />
         </div>
       )}
 
@@ -154,10 +160,15 @@ function Slot(props: {
   return (
     <div
       className={cn(
-        'relative w-10 md:w-20 h-14 md:h-28 text-[2rem] md:text-[4rem] flex items-center justify-center border-border border-y border-r first:border-l first:rounded-l-md last:rounded-r-md transition-all [transition-duration:300ms] outline outline-0 outline-accent-foreground/20',
+        'relative w-10 md:w-20 h-14 md:h-28 text-[2rem] md:text-[4rem] flex items-center justify-center border-border border-y border-r first:border-l first:rounded-l-md last:rounded-r-md',
         'group-hover:border-accent-foreground/20 group-focus-within:!border-accent-foreground/50',
+        'transition-[border-color,box-shadow] duration-300 ease-out',
+        'will-change-[border-color,box-shadow]',
+        'backface-hidden [-webkit-backface-visibility:hidden] [transform:translateZ(0)]',
         {
-          'outline-4 outline-accent-foreground': props.isActive,
+          '[box-shadow:0_0_0_4px_hsl(var(--accent-foreground))]':
+            props.isActive,
+          '[box-shadow:0_0_0_0px_transparent]': !props.isActive,
         },
       )}
     >

--- a/apps/website/tailwind.config.ts
+++ b/apps/website/tailwind.config.ts
@@ -104,8 +104,8 @@ const config = {
         1500: '1500ms',
       },
       transitionTimingFunction: {
-        'default': 'ease-out',
-      }
+        default: 'ease-out',
+      },
     },
   },
   plugins: [require('tailwindcss-animate')],


### PR DESCRIPTION
## Problem

The OTP input slot border animation on the website landing page was jerky and not smooth when slots became active or inactive. The animation appeared to "lag" as pixels grew incrementally rather than smoothly transitioning.

## Solution

Optimized CSS transitions by:

- Replaced `transition-all` with specific properties (`border-color`, `box-shadow`) to avoid animating unnecessary properties
- Replaced `outline` with `box-shadow` for better animation performance
- Added GPU acceleration: `will-change`, `backface-visibility: hidden`, `transform: translateZ(0)`
- Uses pure CSS transitions that work automatically in both directions

## Result
Smooth border animation when clicking on/away from slots.

## Visuals

The old beheviour:

https://github.com/user-attachments/assets/1720a58b-f75b-4512-87fc-71073c165e54

The new behaviour:

https://github.com/user-attachments/assets/4cba5896-d08d-4fb3-a1d9-943f7beb8a43
