### PR TITLE
Stop reserving the password manager gutter for everyone

### DIFF
--- a/apps/playground/src/tests/base.pwm-badge.spec.ts
+++ b/apps/playground/src/tests/base.pwm-badge.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test'
+
+// The fallback badge probe runs on focus and re-runs at 2s and 5s.
+// Waiting past the second probe proves the "no badge" verdict is stable
+// and not just the pre-focus default.
+const SECOND_PROBE_DELAY = 2_500
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/base')
+})
+
+test.describe('Base tests - Password manager badge', () => {
+  test('should not reserve badge space when no password manager is present', async ({
+    page,
+  }) => {
+    const input = page.getByRole('textbox')
+
+    await input.focus()
+    await expect(input).toBeFocused()
+
+    await expect(input).toHaveJSProperty('style.width', '100%')
+    await expect(input).toHaveJSProperty('style.clipPath', '')
+
+    await page.waitForTimeout(SECOND_PROBE_DELAY)
+
+    await expect(input).toHaveJSProperty('style.width', '100%')
+    await expect(input).toHaveJSProperty('style.clipPath', '')
+  })
+
+  test('should reserve badge space when a password manager is detected', async ({
+    page,
+  }) => {
+    // Same marker attribute the library looks for (LastPass).
+    await page.evaluate(() => {
+      const badge = document.createElement('div')
+      badge.setAttribute('data-lastpass-icon-root', '')
+      document.body.appendChild(badge)
+    })
+
+    const input = page.getByRole('textbox')
+
+    await input.focus()
+    await expect(input).toBeFocused()
+
+    await expect(input).toHaveJSProperty('style.width', 'calc(100% + 40px)')
+    await expect(input).toHaveJSProperty(
+      'style.clipPath',
+      'inset(0px 40px 0px 0px)',
+    )
+  })
+})

--- a/packages/input-otp/src/use-pwm-badge.tsx
+++ b/packages/input-otp/src/use-pwm-badge.tsx
@@ -57,16 +57,17 @@ export function usePasswordManagerBadge({
       return
     }
 
-    const elementToCompare = container
+    // Probe against the container's box, not the input's: once the badge
+    // space is pushed the input grows wider than the field it renders.
+    const elementToProbe = container
 
     // Get the top right-center point of the container.
     // That is usually where most password managers place their badge.
     const rightCornerX =
-      elementToCompare.getBoundingClientRect().left +
-      elementToCompare.offsetWidth
+      elementToProbe.getBoundingClientRect().left + elementToProbe.offsetWidth
     const centereredY =
-      elementToCompare.getBoundingClientRect().top +
-      elementToCompare.offsetHeight / 2
+      elementToProbe.getBoundingClientRect().top +
+      elementToProbe.offsetHeight / 2
     const x = rightCornerX - PWM_BADGE_MARGIN_RIGHT
     const y = centereredY
 
@@ -82,7 +83,9 @@ export function usePasswordManagerBadge({
       // If the found element is the input itself,
       // then we assume it's not a password manager badge.
       // We are not sure. Most times that means there isn't a badge.
-      if (maybeBadgeEl === container) {
+      // A null result means the point is off-screen, so we learned nothing
+      // and must not claim a badge is there either.
+      if (!maybeBadgeEl || maybeBadgeEl === input) {
         return
       }
     }


### PR DESCRIPTION
The fallback badge probe has been saying "yes, there's a badge" for every focused field since before 1.4.2, regardless of whether any password manager is installed.

## The bug

```ts
const maybeBadgeEl = document.elementFromPoint(x, y)
if (maybeBadgeEl === container) {
  return // nothing sitting on top of the field
}
```

That comparison can never be true. The invisible input is the one node in the field with `pointer-events: all`, so it is always the topmost element at the probe point — never the container. The guard never fires, the probe falls through to "there is a badge", and every focused field reserves 40px of gutter.

Compare against the input instead. A `null` hit — the probe point is off-screen — now also counts as *learned nothing* rather than as a badge, which was the other way the old branch could claim a badge that wasn't there.

## Why nobody noticed

Nothing visibly changed either way: the clip-path hides the extra width and clips hit-testing along with it. That's how it survived to 1.4.2. It's a correctness fix, not a visible one — though anyone reading `input.style.width` in a test or a devtools panel saw the wrong thing.

## Verification

Added `base.pwm-badge.spec.ts`, and checked it's a real regression test rather than a vacuous one:

- **With the fix:** both cases pass.
- **With the fix reverted:** the "no password manager" case fails with exactly the reported symptom — `unexpected value "calc(100% + 40px)"` where `100%` was expected — while the "manager detected" case still passes, so the fix doesn't just disable detection.

The assertions wait past the 2s re-probe, so a pass means the "no badge" verdict is stable rather than just the pre-focus default.

Tests were run on an isolated port: the shared Playwright config hardcodes 3039 with `reuseExistingServer`, and another worktree's dev server was already holding it, which would have silently tested the wrong build.

## Note

The docs pages describing this probe are updated in the landing PR (#116), and they describe the *fixed* behaviour — including a live simulator that tells the reader to select "None" and watch `width` stay at `100%`. That's only true once this merges, so **this should land before #116**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)