### PR TITLE
Releases stop happening by accident

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           version: 9
       - run: pnpm install
+      - run: pnpm type-check
       - run: pnpm exec playwright install --with-deps
       - run: pnpm test
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,116 @@
+name: Release
+
+# Publishing is triggered by a tag, never by a merge. Cut one with
+# `pnpm release:beta` / `pnpm release:minor` — see scripts/release.mjs.
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to publish, e.g. v1.5.0-beta.1'
+        required: true
+
+permissions:
+  contents: write # create the GitHub release
+  id-token: write # provenance attestation + npm trusted publishing
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+
+      # npm >= 11.5.1 is what supports trusted publishing (OIDC).
+      - run: npm install -g npm@latest
+
+      - name: Resolve tag, verify it matches package.json, pick dist-tag
+        id: meta
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
+          PKG_VERSION="$(node -p "require('./packages/input-otp/package.json').version")"
+
+          if [ "$VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag $TAG does not match packages/input-otp/package.json ($PKG_VERSION)"
+            exit 1
+          fi
+
+          # 1.5.0-beta.1 -> beta   |   1.5.0 -> latest
+          case "$VERSION" in
+            *-*) NPM_TAG="${VERSION#*-}"; NPM_TAG="${NPM_TAG%%.*}"; PRERELEASE=true ;;
+            *)   NPM_TAG=latest; PRERELEASE=false ;;
+          esac
+
+          {
+            echo "tag=$TAG"
+            echo "version=$VERSION"
+            echo "npm_tag=$NPM_TAG"
+            echo "prerelease=$PRERELEASE"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Publishing $TAG to npm dist-tag '$NPM_TAG'"
+
+      - run: pnpm install --frozen-lockfile
+
+      # `pnpm lint:lib` is deliberately absent: eslint is not installed for
+      # packages/input-otp, so the script fails on any machine. Add it back
+      # here once that devDependency exists.
+      - run: pnpm type-check
+
+      - run: pnpm exec playwright install --with-deps
+      - run: pnpm test
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: apps/playground/playwright-report/
+          retention-days: 30
+
+      - run: pnpm build:lib
+
+      # Uses NPM_TOKEN today. To switch to npm trusted publishing: configure
+      # this repo + workflow as a trusted publisher on npmjs.com, then delete
+      # the `env:` block below — OIDC takes over and there is no token to rotate.
+      - name: Publish to npm
+        working-directory: packages/input-otp
+        run: npm publish --provenance --access public --tag "${{ steps.meta.outputs.npm_tag }}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          # Pull this version's section out of the hand-written changelog.
+          awk -v v="$VERSION" '
+            $0 ~ "^## *\\[?" v "\\]?" { found = 1; next }
+            found && /^## / { exit }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+
+          if [ -s release-notes.md ]; then
+            NOTES=(--notes-file release-notes.md)
+          else
+            NOTES=(--generate-notes)
+          fi
+
+          gh release create "$TAG" --title "$TAG" \
+            ${{ steps.meta.outputs.prerelease == 'true' && '--prerelease' || '--latest' }} \
+            "${NOTES[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,13 @@ playwright/.cache/
 
 # next.js
 .next/
+.next-dev/
 out/
 build
 next-env.d.ts
+
+# vercel
+.vercel
 
 # misc
 .DS_Store
@@ -39,3 +43,4 @@ yarn-error.log*
 
 # post-build
 packages/input-otp/README.md
+packages/input-otp/LICENSE

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,7 +8,10 @@ Two things ship from this repo, and they ship independently.
 | The npm package (`input-otp`)      | tags `v*`           | you push a `v*` tag              |
 
 `master` is neither. It is the integration branch: merge into it freely, nothing
-user-facing moves. Vercel builds it as a preview at `next.input-otp.rodz.dev`.
+user-facing moves. Vercel builds every push to it as a preview, always reachable
+at the same URL:
+
+https://rodz-input-otp-git-master-rodzs-projects-5bc7c768.vercel.app
 
 ## Ship the website
 
@@ -54,11 +57,16 @@ If a publish fails halfway, re-run the workflow from the Actions tab with
 
 ## One-time setup
 
-- Vercel → Settings → Git → **Production Branch** = `production`
-- Vercel → Domains → assign `next.input-otp.rodz.dev` to branch `master`
+- ~~Vercel → Settings → Git → **Production Branch** = `production`~~ — done.
 - Repo secret `NPM_TOKEN` (automation token). To drop the token entirely,
   configure this repo + `release.yml` as a trusted publisher on npmjs.com and
   delete the `env:` block on the publish step — OIDC takes over.
+
+Optional: a prettier staging hostname. `rodz.dev` is on Google Cloud DNS, not
+Vercel, so it needs a `CNAME next.input-otp → cname.vercel-dns.com` record
+created there first, then the domain added to the project and assigned to branch
+`master`. The `*-git-master-*.vercel.app` alias above already works without any
+of that.
 
 ## Notes
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,71 @@
+# Releasing
+
+Two things ship from this repo, and they ship independently.
+
+|                                    | Lives on            | Ships when                       |
+| ---------------------------------- | ------------------- | -------------------------------- |
+| The website (`input-otp.rodz.dev`) | branch `production` | you push `master` → `production` |
+| The npm package (`input-otp`)      | tags `v*`           | you push a `v*` tag              |
+
+`master` is neither. It is the integration branch: merge into it freely, nothing
+user-facing moves. Vercel builds it as a preview at `next.input-otp.rodz.dev`.
+
+## Ship the website
+
+```bash
+pnpm ship:site     # git push origin master:production
+```
+
+Fast-forward only. `git log production` is an accurate record of what is live.
+
+## Ship the package
+
+1. Write the entry in `CHANGELOG.md` first — `## [1.5.0-beta.1]`, prose, by hand.
+   The release script refuses to cut a version that has no section.
+2. Make sure `master` is pushed and CI is green. The script refuses to tag
+   unpushed commits.
+3. Cut it:
+
+```bash
+pnpm release:beta:first   # 1.4.2 → 1.5.0-beta.0   start a beta line
+pnpm release:beta         # → 1.5.0-beta.1         bump an existing beta
+pnpm release:minor        # → 1.5.0                promote to stable
+pnpm release:patch
+pnpm release:major
+pnpm release:dry          # print what would happen, change nothing
+```
+
+That bumps `packages/input-otp/package.json`, commits, tags, pushes. **It does
+not publish.** The tag triggers `.github/workflows/release.yml`, which re-runs
+the whole suite on a clean checkout and publishes from CI with provenance, then
+opens a GitHub release using that changelog section.
+
+Pre-release versions land on their own npm dist-tag (`1.5.0-beta.1` → `beta`) and
+leave `latest` alone. Only a stable version moves `latest`.
+
+To publish an exact version, bypassing the bump keywords:
+
+```bash
+node scripts/release.mjs 1.5.0-beta.1
+```
+
+If a publish fails halfway, re-run the workflow from the Actions tab with
+`workflow_dispatch` and the existing tag — no new tag needed.
+
+## One-time setup
+
+- Vercel → Settings → Git → **Production Branch** = `production`
+- Vercel → Domains → assign `next.input-otp.rodz.dev` to branch `master`
+- Repo secret `NPM_TOKEN` (automation token). To drop the token entirely,
+  configure this repo + `release.yml` as a trusted publisher on npmjs.com and
+  delete the `env:` block on the publish step — OIDC takes over.
+
+## Notes
+
+- Nothing publishes from a laptop. There is no bypass script; if you need to skip
+  a check, fix the check.
+- `apps/website` depends on `input-otp: workspace:*`, so the docs site always
+  reflects `master`, not npm. That is intentional — but it means the staging site
+  can document APIs that are not published yet.
+- The npm `beta` dist-tag sat at `1.2.0-beta.1` from March 2024 until the 1.5
+  line. Cutting a beta refreshes it.

--- a/package.json
+++ b/package.json
@@ -22,10 +22,13 @@
     "type-check": "turbo run type-check",
     "lint:lib": "turbo run lint --filter=input-otp",
     "format": "prettier --write .",
-    "release": "run-s test build:lib && cd ./packages/input-otp && cp ../../README.md . && pnpm release && rimraf ./README.md && cd ../..",
-    "release:bypass": "run-s build:lib && cd ./packages/input-otp && cp ../../README.md . && pnpm release && rimraf ./README.md && cd ../..",
-    "release:beta": "run-s test build:lib && cd ./packages/input-otp && cp ../../README.md . && pnpm release:beta && rimraf ./README.md && cd ../..",
-    "release:beta:bypass": "run-s build:lib && cd ./packages/input-otp && cp ../../README.md . && pnpm release:beta && rimraf ./README.md && cd ../.."
+    "ship:site": "git push origin master:production",
+    "release:beta:first": "node scripts/release.mjs preminor --preid beta",
+    "release:beta": "node scripts/release.mjs prerelease --preid beta",
+    "release:patch": "node scripts/release.mjs patch",
+    "release:minor": "node scripts/release.mjs minor",
+    "release:major": "node scripts/release.mjs major",
+    "release:dry": "node scripts/release.mjs prerelease --preid beta --dry-run"
   },
   "prettier": {
     "tabWidth": 2,

--- a/packages/input-otp/package.json
+++ b/packages/input-otp/package.json
@@ -38,7 +38,8 @@
   "scripts": {
     "type-check": "tsc --noEmit",
     "copy-readme": "cp ../../README.md ./README.md",
-    "build": "run-s build:* copy-readme",
+    "copy-license": "cp ../../LICENSE ./LICENSE",
+    "build": "run-s build:* copy-readme copy-license",
     "build:tsup": "tsup --dts --minify",
     "clean": "rimraf dist",
     "dev": "tsup --watch --dts",
@@ -48,9 +49,7 @@
     "lint:format": "prettier --check \"src/**/*.ts\"",
     "lint:format:fix": "prettier --check \"src/**/*.ts\" --write",
     "lint:tsc": "tsc --project tsconfig.json --noEmit",
-    "format": "prettier --write .",
-    "release": "npm publish",
-    "release:beta": "npm publish --tag beta"
+    "format": "prettier --write ."
   },
   "eslintConfig": {
     "root": true,

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// Cuts a release: bumps the package version, commits, tags, pushes.
+//
+// It does NOT publish. Pushing the tag is what publishes — .github/workflows/
+// release.yml picks it up, re-runs the full test suite on a clean checkout and
+// publishes from CI with provenance. Nothing is ever published from a laptop.
+//
+//   node scripts/release.mjs <patch|minor|major|prerelease|1.2.3> [--preid beta] [--dry-run]
+//
+// Starting a beta line for the next minor needs `preminor`, not `prerelease`
+// (1.4.2 + prerelease = 1.4.3-beta.0, which is not the release you meant):
+//
+//   pnpm release:beta:first   1.4.2       -> 1.5.0-beta.0
+//   pnpm release:beta         1.5.0-beta.0 -> 1.5.0-beta.1
+//   pnpm release:minor        1.5.0-beta.1 -> 1.5.0
+//
+// Or pass the exact version when you want to name it yourself:
+//   node scripts/release.mjs 1.5.0-beta.1
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const PKG_DIR = resolve(ROOT, 'packages/input-otp')
+const RELEASE_BRANCH = 'master'
+
+const run = (cmd, args, opts = {}) =>
+  execFileSync(cmd, args, { cwd: ROOT, encoding: 'utf8', ...opts }).trim()
+
+const die = msg => {
+  console.error(`\n  ✗ ${msg}\n`)
+  process.exit(1)
+}
+
+const args = process.argv.slice(2)
+const dryRun = args.includes('--dry-run')
+const preidIndex = args.indexOf('--preid')
+const preid = preidIndex === -1 ? null : args[preidIndex + 1]
+// Skip the value that belongs to --preid, but only when --preid was passed;
+// otherwise indexOf's -1 would make this swallow the first positional arg.
+const preidValueIndex = preidIndex === -1 ? -1 : preidIndex + 1
+const bump = args.find((a, i) => !a.startsWith('--') && i !== preidValueIndex)
+
+if (!bump) {
+  die(
+    'usage: node scripts/release.mjs <patch|minor|major|prerelease|1.2.3> [--preid beta] [--dry-run]',
+  )
+}
+
+// --- guards ---------------------------------------------------------------
+// A release tag has to point at code that is already on origin and already
+// green. Anything else and CI builds something nobody reviewed.
+
+if (run('git', ['status', '--porcelain'])) {
+  die('Working tree is dirty. Commit or stash first.')
+}
+
+const branch = run('git', ['rev-parse', '--abbrev-ref', 'HEAD'])
+if (branch !== RELEASE_BRANCH) {
+  die(`Releases are cut from ${RELEASE_BRANCH}, but you are on ${branch}.`)
+}
+
+run('git', ['fetch', 'origin', RELEASE_BRANCH, '--tags'])
+const [behind, ahead] = run('git', [
+  'rev-list',
+  '--left-right',
+  '--count',
+  `origin/${RELEASE_BRANCH}...HEAD`,
+]).split(/\s+/)
+
+if (behind !== '0')
+  die(`${RELEASE_BRANCH} is ${behind} commit(s) behind origin. Pull first.`)
+if (ahead !== '0') {
+  die(
+    `${RELEASE_BRANCH} has ${ahead} unpushed commit(s). Push them and let CI go green before tagging.`,
+  )
+}
+
+// --- version --------------------------------------------------------------
+
+const versionArgs = [
+  'version',
+  bump,
+  '--no-git-tag-version',
+  ...(preid ? ['--preid', preid] : []),
+]
+let version
+try {
+  version = run('npm', versionArgs, { cwd: PKG_DIR }).replace(/^v/, '')
+} catch (err) {
+  die(
+    `npm could not apply the bump "${bump}":\n    ` +
+      String(err.stderr || err.message)
+        .trim()
+        .replace(/^npm error /gm, '')
+        .split('\n')[0],
+  )
+}
+const tag = `v${version}`
+const revert = () =>
+  run('git', ['checkout', '--', 'packages/input-otp/package.json'])
+
+const existingTags = run('git', ['tag', '--list', tag])
+if (existingTags) {
+  revert()
+  die(`Tag ${tag} already exists.`)
+}
+
+// The changelog is hand-written prose, and it stays that way — but a release
+// without an entry is a release nobody can read, so require it up front.
+const changelog = readFileSync(resolve(ROOT, 'CHANGELOG.md'), 'utf8')
+const hasEntry = new RegExp(
+  `^##\\s*\\[?${version.replace(/[.\\+]/g, '\\$&')}\\]?`,
+  'm',
+).test(changelog)
+
+if (!hasEntry) {
+  revert()
+  die(
+    `CHANGELOG.md has no section for ${version}.\n` +
+      `    Add one first:  ## [${version}]`,
+  )
+}
+
+const npmTag = version.includes('-')
+  ? version.split('-')[1].split('.')[0]
+  : 'latest'
+
+console.log(`
+  ${tag}  →  npm dist-tag "${npmTag}"
+  ${version.includes('-') ? 'Pre-release: `latest` is left untouched.' : 'Stable: this becomes `latest`.'}
+`)
+
+if (dryRun) {
+  revert()
+  console.log('  --dry-run: nothing committed, package.json restored.\n')
+  process.exit(0)
+}
+
+// --- cut ------------------------------------------------------------------
+
+run('git', ['add', 'packages/input-otp/package.json'])
+run('git', ['commit', '-m', `chore(release): ${tag}`])
+run('git', ['tag', '-a', tag, '-m', tag])
+run('git', ['push', '--follow-tags', 'origin', RELEASE_BRANCH])
+
+console.log(`
+  Pushed ${tag}. CI is publishing:
+  https://github.com/guilhermerodz/input-otp/actions/workflows/release.yml
+`)


### PR DESCRIPTION
`master` currently does two jobs it was never meant to do at once: every merge redeploys the production website, and every publish happens by hand from a laptop. The result is 14 open PRs nobody wants to merge and an npm package that has not shipped since January 2025.

This splits the two release trains apart.

## After this

| | Lives on | Ships when |
|---|---|---|
| Website | branch `production` | `pnpm ship:site` |
| npm package | tags `v*` | `pnpm release:beta` etc. |

`master` becomes the integration branch. Merge into it freely — nothing user-facing moves. Its preview is always at https://rodz-input-otp-git-master-rodzs-projects-5bc7c768.vercel.app

## What's here

- **`scripts/release.mjs`** — bumps, commits, tags, pushes. Never publishes. Guards on: clean tree, on `master`, in sync with origin, no unpushed commits, tag unused, and a hand-written `CHANGELOG.md` section already present for the new version.
- **`.github/workflows/release.yml`** — fires on `v*` tags. Verifies the tag matches `package.json`, re-runs the full Playwright suite on a clean checkout, publishes with `--provenance`, derives the dist-tag from the version (`1.5.0-beta.1` → `beta`, `1.5.0` → `latest`), and opens a GitHub release from that changelog section. `workflow_dispatch` re-runs a failed publish without a new tag.
- **Removed `release:bypass` / `release:beta:bypass`** — they published untested code from a laptop.
- **`type-check` now runs on PRs.**
- **`LICENSE` is now copied into the published package**, which it has never carried.
- **`RELEASING.md`** documents all of it.

## Vercel is already switched over

The `rodz-input-otp` project's Production Branch is now `production` (verified: repo still linked, root dir `apps/website` and build command intact). The `production` branch was created pointing at the same commit `master` was on, so `input-otp.rodz.dev` is serving exactly what it was before.

**This means merging is now safe, but it also means `input-otp.rodz.dev` will not update until someone runs `pnpm ship:site`.**

## Still to do

- Repo secret `NPM_TOKEN`. Or configure trusted publishing on npmjs.com and delete the marked `env:` block on the publish step.

## One thing deliberately left out

`pnpm lint:lib` is **broken on master today** — `eslint` is not a dependency of `packages/input-otp` (only the plugins are), so the script exits with `eslint: command not found`. It is not wired into either workflow here. Fixing it means adding the devDependency and regenerating the lockfile, which needs care: CI pins pnpm 9 and `pnpm-lock.yaml` is `lockfileVersion: 9.0`. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)