### PR TITLE
fix(types): narrow onComplete to (value: string) => unknown

### DIFF
--- a/packages/input-otp/src/types.ts
+++ b/packages/input-otp/src/types.ts
@@ -20,7 +20,7 @@ type OTPInputBaseProps = OverrideProps<
 
     textAlign?: 'left' | 'center' | 'right'
 
-    onComplete?: (...args: any[]) => unknown
+    onComplete?: (value: string) => unknown
     pushPasswordManagerStrategy?: 'increase-width' | 'none'
     pasteTransformer?: (pasted: string) => string
 


### PR DESCRIPTION
## What

`onComplete` is declared in `packages/input-otp/src/types.ts` as:

```ts
onComplete?: (...args: any[]) => unknown
```

but `input.tsx` has only ever called it one way — `onComplete?.(value)` with a single string ([input.tsx:267](https://github.com/guilhermerodz/input-otp/blob/master/packages/input-otp/src/input.tsx#L267)). The README and the docs site both already document it as `(value: string) => unknown`, which is the real runtime contract.

This narrows the declaration to match, so editor autocomplete and hover stop advertising a variadic `any[]` that no call site can populate.

## Compatibility

Type-level only — no runtime change, zero diff in `dist` behavior.

`(value: string) => unknown` is assignable to the old loose type, so existing handlers keep compiling:

- `onComplete={() => setDisabled(true)}` — fine (fewer params is always assignable)
- `onComplete={code => submit(code)}` — fine
- `onComplete={verify}` where `verify(code: string)` — fine

The only thing that newly errors is a handler declaring a second parameter — and there is no value that parameter could ever receive today, so such a handler is already broken at runtime.

I checked every `onComplete` in this repo (playground, website demos, docs examples); all are zero-arg or `(code: string)`.

## 1.5.0

Good candidate to fold into the upcoming 1.5.0 beta — it is a breaking change only in the strictest sense (a handler with extra params stops compiling), so a minor is the right place for it rather than a patch.

No `CHANGELOG.md` entry added: there is no `1.5.0` section yet (the file currently starts at `1.4.2`). Happy to add one under `## [1.5.0]` as part of whatever opens that section, or in a follow-up here if you'd rather it land with this PR.

## One thing to flag, out of scope here

The react-hook-form Controller snippet in the docs passes `handleSubmit(onValid)` to `onComplete`:

`apps/website/src/app/(docs)/docs/forms/page.tsx:59`

That is a code sample inside a template literal, so it does not type-check in CI — but a user copying it would now get an error, since `handleSubmit` returns `(e?: BaseSyntheticEvent) => Promise<void>`. It was already wrong (the handler would receive the code string where it expects an event); the narrowed type just makes that visible. Left alone deliberately — say the word and I will fix the snippet, here or separately.

## Verification

```
cd packages/input-otp && ./node_modules/.bin/tsc --project tsconfig.json --noEmit
```

Passes, exit 0. (Run directly rather than via pnpm, which currently fails locally with `ERR_PNPM_IGNORED_BUILDS` on `esbuild@0.19.12`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)