### PR TITLE
fix(lib): make `pnpm lint:lib` runnable again

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           version: 9
       - run: pnpm install
+      - run: pnpm lint:lib
       - run: pnpm type-check
       - run: pnpm exec playwright install --with-deps
       - run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,9 +66,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # `pnpm lint:lib` is deliberately absent: eslint is not installed for
-      # packages/input-otp, so the script fails on any machine. Add it back
-      # here once that devDependency exists.
+      - run: pnpm lint:lib
       - run: pnpm type-check
 
       - run: pnpm exec playwright install --with-deps

--- a/packages/input-otp/package.json
+++ b/packages/input-otp/package.json
@@ -44,10 +44,10 @@
     "clean": "rimraf dist",
     "dev": "tsup --watch --dts",
     "lint": "run-p lint:*",
-    "lint:eslint": "eslint src --ext .ts",
-    "lint:eslint:fix": "eslint src --ext .ts --fix",
-    "lint:format": "prettier --check \"src/**/*.ts\"",
-    "lint:format:fix": "prettier --check \"src/**/*.ts\" --write",
+    "lint:eslint": "eslint src --ext .ts,.tsx",
+    "lint:eslint:fix": "eslint src --ext .ts,.tsx --fix",
+    "lint:format": "prettier --check \"src/**/*.{ts,tsx}\"",
+    "lint:format:fix": "prettier --check \"src/**/*.{ts,tsx}\" --write",
     "lint:tsc": "tsc --project tsconfig.json --noEmit",
     "format": "prettier --write ."
   },
@@ -110,6 +110,7 @@
   "devDependencies": {
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
+    "eslint": "^8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^5.3.3"

--- a/packages/input-otp/src/input.tsx
+++ b/packages/input-otp/src/input.tsx
@@ -311,14 +311,15 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
     const _pasteListener = React.useCallback(
       (e: React.ClipboardEvent<HTMLInputElement>) => {
         const input = inputRef.current
-        if (!pasteTransformer && (!initialLoadRef.current.isIOS || !e.clipboardData || !input)) {
+        if (
+          !pasteTransformer &&
+          (!initialLoadRef.current.isIOS || !e.clipboardData || !input)
+        ) {
           return
         }
-        
+
         const _content = e.clipboardData.getData('text/plain')
-        const content = pasteTransformer
-          ? pasteTransformer(_content)
-          : _content
+        const content = pasteTransformer ? pasteTransformer(_content) : _content
         e.preventDefault()
 
         const start = inputRef.current?.selectionStart
@@ -345,7 +346,7 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
         setMirrorSelectionStart(_start)
         setMirrorSelectionEnd(_end)
       },
-      [maxLength, onChange, regexp, value],
+      [maxLength, onChange, pasteTransformer, regexp, value],
     )
 
     /** Styles */
@@ -454,6 +455,7 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
         maxLength,
         mirrorSelectionEnd,
         mirrorSelectionStart,
+        placeholder,
         props,
         regexp?.source,
         value,
@@ -472,7 +474,8 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
               (slotIdx >= mirrorSelectionStart && slotIdx < mirrorSelectionEnd))
 
           const char = value[slotIdx] !== undefined ? value[slotIdx] : null
-          const placeholderChar = value[0] !== undefined ? null : placeholder?.[slotIdx] ?? null
+          const placeholderChar =
+            value[0] !== undefined ? null : placeholder?.[slotIdx] ?? null
 
           return {
             char,
@@ -490,6 +493,7 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
       maxLength,
       mirrorSelectionEnd,
       mirrorSelectionStart,
+      placeholder,
       props.disabled,
       value,
     ])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.19
         version: 18.2.21
+      eslint:
+        specifier: ^8
+        version: 8.57.0
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -542,28 +545,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.1.0':
     resolution: {integrity: sha512-v6kP8sHYxjO8RwHmWMJSq7VZP2nYCkRVQ0qolh2l6xroe9QjbgV8siTbduED4u0hlk0+tjS6/Tuy4n5XCp+l6g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.1.0':
     resolution: {integrity: sha512-zJ2pnoFYB1F4vmEVlb/eSe+VH679zT1VdXlZKX+pE66grOgjmKJHKacf82g/sWE4MQ4Rk2FMBCRnX+l6/TVYzQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.1.0':
     resolution: {integrity: sha512-rbaIYFt2X9YZBSbH/CwGAjbBG2/MrACCVu2X0+kSykHzHnYH5FjHxwXLkcoJ10cX0aWCEynpu+rP76x0914atg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.1.0':
     resolution: {integrity: sha512-o1N5TsYc8f/HpGt39OUQpQ9AKIGApd3QLueu7hXk//2xq5Z9OxmV6sQfNp8C7qYmiOlHYODOGqNNa0e9jvchGQ==}
@@ -915,31 +914,26 @@ packages:
     resolution: {integrity: sha512-0bK9aG1kIg0Su7OcFTlexkVeNZ5IzEsnz1ept87a0TUgZ6HplSgkJAnFpEVRW7GRcikT4GlPV0pbtVedOaXHQQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.12.1':
     resolution: {integrity: sha512-qB6AFRXuP8bdkBI4D7UPUbE7OQf7u5OL+R94JE42Z2Qjmyj74FtDdLGeriRyBDhm4rQSvqAGCGC01b8Fu2LthQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.12.1':
     resolution: {integrity: sha512-sHig3LaGlpNgDj5o8uPEoGs98RII8HpNIqFtAI8/pYABO8i0nb1QzT0JDoXF/pxzqO+FkxvwkHZo9k0NJYDedg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.12.1':
     resolution: {integrity: sha512-nD3YcUv6jBJbBNFvSbp0IV66+ba/1teuBcu+fBBPZ33sidxitc6ErhON3JNavaH8HlswhWMC3s5rgZpM4MtPqQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.12.1':
     resolution: {integrity: sha512-7/XVZqgBby2qp/cO0TQ8uJK+9xnSdJ9ct6gSDdEr4MfABrjTyrW6Bau7HQ73a2a5tPB7hno49A0y1jhWGDN9OQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.12.1':
     resolution: {integrity: sha512-CYc64bnICG42UPL7TrhIwsJW4QcKkIt9gGlj21gq3VV0LL6XNb1yAdHVp1pIi9gkts9gGcT3OfUYHjGP7ETAiw==}
@@ -4792,8 +4786,8 @@ snapshots:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.4.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.0(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
@@ -4815,13 +4809,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.1
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -4839,7 +4833,7 @@ snapshots:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.4.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4851,6 +4845,33 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+    dependencies:
+      array-includes: 3.1.7
+      array.prototype.findlastindex: 1.2.4
+      array.prototype.flat: 1.3.2
+      array.prototype.flatmap: 1.3.2
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      hasown: 2.0.1
+      is-core-module: 2.13.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.7
+      object.groupby: 1.0.2
+      object.values: 1.1.7
+      semver: 6.3.1
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.4.2)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
       - supports-color
 
   eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0):


### PR DESCRIPTION
## What

`packages/input-otp` defines `"lint:eslint": "eslint src --ext .ts"`, but eslint was never a dependency — not of the package, not of the workspace root. Only `apps/playground` and `apps/website` declared it. Running `pnpm lint:lib` failed with `sh: eslint: command not found`, and both workflows had quietly dropped the step to stay green (`release.yml` carried a comment explaining why).

## Changes

- **`eslint@^8`** added to `packages/input-otp` devDependencies, matching the version the apps already use (resolves to the 8.57.0 already in the lockfile).
- **Lint globs widened to `.ts,.tsx`.** With `.ts` alone, `input.tsx` and `use-pwm-badge.tsx` — nearly the whole library — were never linted, and the script reported zero problems. It also explains why the `react/jsx-key` and `react-hooks/*` rules configured in `eslintConfig` had nothing to act on. Applied to `lint:eslint`, `lint:eslint:fix`, `lint:format`, and `lint:format:fix`.
- **Three `react-hooks/exhaustive-deps` errors fixed**, each a genuine stale closure:
  - `_pasteListener` reads `pasteTransformer` but didn't list it, so swapping the transformer had no effect until another dep changed.
  - `renderedInput` and `contextValue` both read `placeholder` without listing it, so changing `placeholder` didn't re-render the slots.
- **Prettier drift** in `_pasteListener` (trailing whitespace, unwrapped lines) reformatted — pre-existing, unrelated to the dep-array edits.
- **`pnpm lint:lib` restored** in `playwright.yml` and `release.yml`; the explanatory comment in `release.yml` is deleted.

## Lockfile

Regenerated with **pnpm 9.15.9**, not the local pnpm 11, so `lockfileVersion` stays `'9.0'` for the `pnpm/action-setup` `version: 9` pin both workflows use. Verified `install --frozen-lockfile` succeeds against it under pnpm 9 *and* pnpm 11, so the CI pin needed no bump. Generating with pnpm 11 instead produced a materially different peer-resolution graph, so it was deliberately avoided.

The `ERR_PNPM_IGNORED_BUILDS` issue for `esbuild` was already resolved on master via `onlyBuiltDependencies` in `pnpm-workspace.yaml`; no change needed.

## Verification

`pnpm lint:lib` passes — eslint, prettier, and tsc all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)