### PR TITLE
fix(input): opt the container out of browser translation

### DIFF
--- a/packages/input-otp/src/input.tsx
+++ b/packages/input-otp/src/input.tsx
@@ -534,6 +534,10 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
         <div
           ref={containerRef}
           data-input-otp-container
+          // Chrome's translation feature rewrites the slots' text nodes
+          // (wrapping them in <font>), which crashes React on the next
+          // update — and a one-time code is never meaningful to translate.
+          translate="no"
           style={rootStyle}
           className={containerClassName}
         >


### PR DESCRIPTION
## What

Adds `translate="no"` to the container element.

## Why

Chrome's translation feature rewrites the slots' text nodes (wrapping them in `<font>` elements). React then crashes on the next re-render when it tries to reconcile DOM it no longer owns — reported in #98 with alphanumeric codes, where backspacing a translated character brings the component down (Chrome translated a slot's `y` to `VE` in Turkish).

A one-time code is never meaningful to translate, so opting the container (and everything rendered inside it) out is strictly correct.

Resolves #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)