### PR TITLE
fix(input): log CSS rule insertion failures as warnings, not errors

### DIFF
--- a/packages/input-otp/src/input.tsx
+++ b/packages/input-otp/src/input.tsx
@@ -559,7 +559,11 @@ function safeInsertRule(sheet: CSSStyleSheet, rule: string) {
   try {
     sheet.insertRule(rule)
   } catch {
-    console.error('input-otp could not insert CSS rule:', rule)
+    // Some environments reject individual selectors (e.g. `:autofill` in
+    // older WebViews). Losing one of these cosmetic rules never breaks the
+    // input, so it must not look like an application error — error-level
+    // logs end up in monitoring tools like Sentry.
+    console.warn('input-otp could not insert CSS rule:', rule)
   }
 }
 


### PR DESCRIPTION
## What

`safeInsertRule` now logs with `console.warn` instead of `console.error`.

## Why

Some environments reject individual selectors — `[data-input-otp]:autofill` in older Android WebViews (#108), and whatever produced the reports in #84. Losing one of these cosmetic rules never breaks the input: autofill still works, the UI renders correctly. But `console.error` is captured by Sentry and similar monitoring tools as if the application had failed, generating noise for every team running error tracking.

The message is unchanged; only the level drops. (#84 also proposed appending the rule as a text node on failure — deliberately not taken: a selector the CSS parser rejected via `insertRule` is rejected the same way when parsed from text, so the fallback could never help.)

Resolves #84
Resolves #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)