### PR TITLE
fix(input): clip the badge gutter so it cannot shift the layout

### DIFF
--- a/packages/input-otp/src/input.tsx
+++ b/packages/input-otp/src/input.tsx
@@ -544,6 +544,14 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
               position: 'absolute',
               inset: 0,
               pointerEvents: 'none',
+              // The input grows 40px past the container while pushing a
+              // password manager badge, which otherwise registers as
+              // scrollable overflow on ancestors and shifts the layout.
+              // The badge itself lives in the extension's own overlay, so
+              // clipping here hides nothing. `clip` rather than `hidden`:
+              // a hidden box is still programmatically scrollable, and a
+              // caret near the input's far edge could drag it sideways.
+              overflowX: 'clip',
             }}
           >
             {renderedInput}


### PR DESCRIPTION
## What

The input's absolute positioning wrapper gets `overflow-x: clip`.

## Why

While pushing a password manager badge, the invisible input grows to `calc(100% + 40px)`. `clip-path` already hides the extension visually and from hit-testing, but the box itself still counts as **scrollable overflow** — so inside a constrained scroll container (a card, a modal, or the viewport) it produced a horizontal scrollbar and the layout shift reported in #107.

## Why this is safe for the badge feature

The 40px gutter exists to move the password manager badge off the last slot. The badge is rendered by the extension in its **own overlay DOM**, positioned against the input's bounding box — and clipping an element changes neither its bounding box nor another element's overlay. Verified against the docs site's PWM simulator.

`clip` rather than `hidden` because a `hidden` box is still a programmatic scroll target: a caret movement near the input's far edge could scroll the wrapper sideways and misalign the field. `clip` is not scrollable. Browsers too old to know `clip` ignore the declaration and simply keep today's behavior.

Resolves #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)