### PR TITLE
fix(website): restyle the section focus ring after the eased scroll

### DIFF
--- a/apps/website/src/app/(experiment)/experiment.css
+++ b/apps/website/src/app/(experiment)/experiment.css
@@ -2075,6 +2075,16 @@ html {
   color: #a1a1aa;
 }
 
+/* The eased scroll (scroll-link.tsx) hands focus to the section it lands on
+   so tabbing continues from there. The UA paints that focus as its stock
+   thick blue ring around the whole section — swap it for a hairline in the
+   page's greys. Scoped to [tabindex] so it only ever touches sections the
+   scroll handoff has focused. */
+.xp section[tabindex]:focus {
+  outline: 1px solid #3f3f46;
+  outline-offset: -1px;
+}
+
 /* Footer ------------------------------------------------------------------- */
 
 /* The wrapper owns the box: before /rodz-signature.js upgrades it, the custom


### PR DESCRIPTION
The eased long-scroll hands keyboard focus to the section it lands on. The UA painted that focus as its stock thick blue ring around the whole "How I built it" rect, which clashed with the site's palette.

This swaps it for a 1px hairline in the page's border greys (`#3f3f46`, `outline-offset: -1px`), scoped to `section[tabindex]:focus` so it only ever applies to sections the scroll handoff has focused.

Verified in headless Chromium: after clicking "How I Built It", the section is focused with a 1px `rgb(63, 63, 70)` outline — no blue ring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)