### PR TITLE
feat(website): mobile tutorial polish and replayable footer signature

### DIFF
--- a/apps/website/src/app/(experiment)/_components/footer-signature.tsx
+++ b/apps/website/src/app/(experiment)/_components/footer-signature.tsx
@@ -25,8 +25,9 @@ export function FooterSignature() {
   const hostRef = React.useRef<HTMLDivElement>(null)
 
   /* The element animates the moment the script upgrades it, which happens
-     long before anyone reaches the footer. Restart the signing when it
-     actually scrolls into view so the visitor sees it drawn. */
+     long before anyone reaches the footer. Restart the signing every time it
+     scrolls into view — the observer stays on for good, so leaving and
+     coming back replays the whole performance. */
   React.useEffect(() => {
     const host = hostRef.current
     if (!host) return
@@ -35,7 +36,6 @@ export function FooterSignature() {
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (!entry.isIntersecting) return
-        observer.disconnect()
         customElements.whenDefined('rodz-signature').then(() => {
           if (cancelled) return
           host.querySelector<SignatureElement>('rodz-signature')?.replay?.()

--- a/apps/website/src/app/(experiment)/_components/hero-otp.tsx
+++ b/apps/website/src/app/(experiment)/_components/hero-otp.tsx
@@ -572,10 +572,9 @@ export function HeroOtp() {
 
   const steps: React.ReactNode[] = isMobile
     ? [
-        <>long-press the code and tap Select All</>,
+        <>double-tap the code and tap Select All</>,
         <>tap Cut — the whole code lifts out</>,
-        <>long-press and Paste it back</>,
-        <>drag the handles around part of it, then cut or paste just that</>,
+        <>double-tap and Paste it back</>,
       ]
     : [
         <>
@@ -602,7 +601,9 @@ export function HeroOtp() {
       ]
   const cutStep = 1
   const pasteStep = 2
-  const sliceStep = isMobile ? 3 : 4
+  /* Desktop only: the mobile tour ends at the paste — selection handles
+     aren't a thing input-otp supports yet, so there is no slice beat. */
+  const sliceStep = isMobile ? -1 : 4
   const finished = shown >= steps.length
 
   // Selection-driven steps advance when the user actually does the thing.
@@ -770,6 +771,36 @@ export function HeroOtp() {
             pointerEvents: 'none',
           }}
         />
+
+        {/* On phones the step also floats above the input, out of flow: the
+            iOS context menu opens right over the status line below, so the
+            copy has to survive in a second place. aria-hidden — it is a
+            visual echo of the line under the input, not new content. */}
+        {isMobile && mode === 'tutorial' && !finished && (
+          <div
+            aria-hidden
+            style={{
+              position: 'absolute',
+              bottom: '100%',
+              left: '50%',
+              transform: 'translateX(-50%)',
+              width: 'max-content',
+              maxWidth: '90vw',
+              marginBottom: 14,
+              fontSize: 14,
+              textAlign: 'center',
+              pointerEvents: 'none',
+            }}
+          >
+            <div
+              key={`step-${shown}`}
+              className={`xp-fade-text ${leaving ? 'xp-fade-text--out' : ''}`}
+              style={{ color: '#a1a1aa' }}
+            >
+              {steps[shown]}
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Status line: error nudge → success → guided tour, all on fades */}

--- a/apps/website/src/app/(experiment)/experiment-view.tsx
+++ b/apps/website/src/app/(experiment)/experiment-view.tsx
@@ -451,9 +451,11 @@ export function ExperimentView({
         }}
         data-rv-group
       >
-        <div data-rv="chrome">
+        {/* The signature is a second door to X, same as the logo across
+            the footer. */}
+        <a data-rv="chrome" href={X_URL} aria-label="Guilherme Rodz on X">
           <FooterSignature />
-        </div>
+        </a>
         <a
           data-rv="chrome"
           className="xp-footer-x"


### PR DESCRIPTION
Mobile hero tutorial:

- Steps say **double-tap** instead of long-press
- The step copy now also floats **above** the input on phones — an absolutely positioned, `aria-hidden` echo of the status line, so the iOS context menu (which opens right over the line below the input) can never hide the instruction. Out-of-flow, so page layout is untouched (verified: the input's position is pixel-identical with and without the floating label)
- The "drag the handles around" beat is gone — input-otp has no handle-drag feature to demo — so the mobile tour ends at the paste with the closing "that's input-otp!" line

Footer signature:

- Tapping the signature goes to https://x.com/guilherme_rodz (same destination as the X logo)
- The signing animation replays every time the signature re-enters the viewport, not just the first time

Verified in headless Chromium (iPhone 13 emulation for the tour): both labels render the same step text, select-all → cut → paste walks the tour to the finish line, and the signature's strokes redraw mid-animation on every viewport re-entry before settling fully drawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)