### PR TITLE
feat: select slots by click, tap and drag

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ invisible input has to behave like six boxes — and the fix for each:
 |                                             |                                                                                                                                                                    |
 | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | A collapsed caret has no slot               | The selection is rewritten into a one-character range on every `selectionchange` — except at the append position, where a bare caret is meaningful                 |
+| Clicking a slot can't reach that slot       | Pointer gestures are mapped onto the rendered slots: click or tap selects the slot under the pointer, dragging extends the selection across slots                  |
+| iOS long-press must keep the paste menu     | A touch held still past ~400ms is handed back to the platform untouched, so the native caret loupe and edit menu present exactly as before                        |
 | `ArrowLeft` appears to skip a slot          | Direction is inferred from the previous selection, with a guard for leaving insert mode                                                                            |
 | Deleting doesn't fire `selectionchange`     | The event is dispatched by hand when the value shrinks                                                                                                             |
 | Password manager badges cover the last slot | A badge is detected by known extension markers, then by probing the field's top-right corner; the input widens 40px behind a `clip-path` — no visible layout shift |
@@ -198,6 +200,12 @@ interface SlotProps {
   hasFakeCaret: boolean
 }
 ```
+
+Tag each rendered slot element with `data-input-otp-slot` and pointer
+selection (click/tap/drag) maps hits to the exact slot geometry; shadcn/ui's
+`data-slot="input-otp-slot"` is detected automatically. Untagged renderers
+fall back to splitting the container width evenly — exact for uniform slots,
+approximate around separators.
 
 Every other `<input>` attribute is forwarded — `name`, `required`, `disabled`,
 `autoFocus`, `aria-*`, `data-*` — and `ref` points at the real input.

--- a/apps/playground/src/components/base-input.tsx
+++ b/apps/playground/src/components/base-input.tsx
@@ -32,6 +32,7 @@ export function BaseOTPInput(
             <div
               data-testid={`slot-${idx}`}
               data-test-char={slot.char ?? undefined}
+              data-input-otp-slot
               key={idx}
               className={cn(
                 'transition-all duration-300 rounded-md border-black bg-white text-black w-10 h-14 border-[4px]',

--- a/apps/playground/src/tests/base.pointer-selections.spec.ts
+++ b/apps/playground/src/tests/base.pointer-selections.spec.ts
@@ -1,0 +1,363 @@
+import { test, expect, Page } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/base')
+})
+
+/**
+ * Wait until the component's mirrored selection (mss/mse) settles at the
+ * expected range. Pointer-driven selection updates are applied through
+ * React state, so polling the mirrored attributes keeps these tests
+ * deterministic without arbitrary waits.
+ */
+async function expectMirrorSelection(page: Page, start: number, end: number) {
+  const input = page.getByRole('textbox')
+  await expect(input).toHaveAttribute('data-input-otp-mss', String(start))
+  await expect(input).toHaveAttribute('data-input-otp-mse', String(end))
+}
+
+async function slotCenter(page: Page, idx: number) {
+  const box = await page.getByTestId(`slot-${idx}`).boundingBox()
+  if (!box) {
+    throw new Error(`slot-${idx} has no bounding box`)
+  }
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+}
+
+/**
+ * Dispatch a synthetic touch-pointer event sequence on the input. Playwright
+ * can only synthesize taps for real touchscreens, so drags and long-presses
+ * are dispatched as PointerEvents directly — they bubble to React's root
+ * listener exactly like real ones. Native side effects (focus on tap end,
+ * caret placement) don't run for synthetic events, which is fine: these
+ * tests target the library's own gesture logic.
+ */
+async function dispatchTouch(
+  page: Page,
+  events: Array<{ type: string; x: number; y: number }>,
+) {
+  await page.evaluate(evts => {
+    const input = document.querySelector('input[data-input-otp]')
+    if (!input) {
+      throw new Error('input not found')
+    }
+    for (const evt of evts) {
+      input.dispatchEvent(
+        new PointerEvent(evt.type, {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          pointerId: 99,
+          pointerType: 'touch',
+          isPrimary: true,
+          clientX: evt.x,
+          clientY: evt.y,
+          button: evt.type === 'pointermove' ? -1 : 0,
+          buttons: evt.type === 'pointerup' ? 0 : 1,
+        }),
+      )
+    }
+  }, events)
+}
+
+test.describe('Base tests - Pointer Selections', () => {
+  test('should select a filled slot on click and replace it when typing', async ({
+    page,
+  }) => {
+    const input = page.getByRole('textbox')
+    await input.pressSequentially('123456')
+
+    const c = await slotCenter(page, 2)
+    await page.mouse.click(c.x, c.y)
+    await expectMirrorSelection(page, 2, 3)
+
+    await page.keyboard.press('9')
+    await expect(input).toHaveValue('129456')
+  })
+
+  test('should keep the caret at the end when clicking past the filled slots', async ({
+    page,
+  }) => {
+    const input = page.getByRole('textbox')
+    await input.pressSequentially('12')
+
+    const c = await slotCenter(page, 4)
+    await page.mouse.click(c.x, c.y)
+    await expectMirrorSelection(page, 2, 2)
+
+    await page.keyboard.press('3')
+    await expect(input).toHaveValue('123')
+  })
+
+  test('should focus an empty input on click with the caret at the first slot', async ({
+    page,
+  }) => {
+    const input = page.getByRole('textbox')
+
+    const c = await slotCenter(page, 3)
+    await page.mouse.click(c.x, c.y)
+    await expect(input).toBeFocused()
+    await expectMirrorSelection(page, 0, 0)
+
+    await page.keyboard.press('7')
+    await expect(input).toHaveValue('7')
+  })
+
+  test('should select a range by dragging across slots', async ({ page }) => {
+    const input = page.getByRole('textbox')
+    await input.pressSequentially('123456')
+
+    const from = await slotCenter(page, 1)
+    const to = await slotCenter(page, 4)
+    await page.mouse.move(from.x, from.y)
+    await page.mouse.down()
+    await page.mouse.move(to.x, to.y, { steps: 8 })
+    // Selection is live while still dragging
+    await expectMirrorSelection(page, 1, 5)
+    await page.mouse.up()
+    await expectMirrorSelection(page, 1, 5)
+
+    // Typing replaces the whole dragged range
+    await page.keyboard.press('9')
+    await expect(input).toHaveValue('196')
+  })
+
+  test('should select a range when dragging right to left', async ({
+    page,
+  }) => {
+    const input = page.getByRole('textbox')
+    await input.pressSequentially('123456')
+
+    const from = await slotCenter(page, 4)
+    const to = await slotCenter(page, 1)
+    await page.mouse.move(from.x, from.y)
+    await page.mouse.down()
+    await page.mouse.move(to.x, to.y, { steps: 8 })
+    await page.mouse.up()
+    await expectMirrorSelection(page, 1, 5)
+  })
+
+  test('should clamp a drag to the filled slots', async ({ page }) => {
+    const input = page.getByRole('textbox')
+    await input.pressSequentially('123')
+
+    const from = await slotCenter(page, 1)
+    const to = await slotCenter(page, 5)
+    await page.mouse.move(from.x, from.y)
+    await page.mouse.down()
+    await page.mouse.move(to.x, to.y, { steps: 8 })
+    await page.mouse.up()
+    await expectMirrorSelection(page, 1, 3)
+  })
+
+  test('should focus and select when dragging on an unfocused input', async ({
+    page,
+  }) => {
+    const input = page.getByRole('textbox')
+    await input.pressSequentially('123456')
+    await input.evaluate(el => (el as HTMLInputElement).blur())
+    await expect(input).not.toBeFocused()
+
+    const from = await slotCenter(page, 0)
+    const to = await slotCenter(page, 2)
+    await page.mouse.move(from.x, from.y)
+    await page.mouse.down()
+    await page.mouse.move(to.x, to.y, { steps: 8 })
+    await page.mouse.up()
+
+    await expect(input).toBeFocused()
+    await expectMirrorSelection(page, 0, 3)
+  })
+
+  test('should select all slots on double click', async ({ page }) => {
+    const input = page.getByRole('textbox')
+    await input.pressSequentially('123456')
+
+    const c = await slotCenter(page, 2)
+    await page.mouse.dblclick(c.x, c.y)
+    await expectMirrorSelection(page, 0, 6)
+  })
+
+  test('should select the tapped slot via touch pointers', async ({
+    page,
+  }) => {
+    const input = page.getByRole('textbox')
+    await input.pressSequentially('123456')
+
+    const c = await slotCenter(page, 1)
+    // Touch applies the selection on release, so a scroll gesture starting
+    // on the input never moves the selection
+    await dispatchTouch(page, [{ type: 'pointerdown', x: c.x, y: c.y }])
+    await expectMirrorSelection(page, 5, 6)
+    await dispatchTouch(page, [{ type: 'pointerup', x: c.x, y: c.y }])
+    await expectMirrorSelection(page, 1, 2)
+  })
+
+  test('should select a range by dragging via touch pointers', async ({
+    page,
+  }) => {
+    const input = page.getByRole('textbox')
+    await input.pressSequentially('123456')
+
+    const from = await slotCenter(page, 1)
+    const to = await slotCenter(page, 4)
+    const steps = 5
+    await dispatchTouch(page, [
+      { type: 'pointerdown', x: from.x, y: from.y },
+      ...Array.from({ length: steps }, (_, i) => ({
+        type: 'pointermove',
+        x: from.x + ((to.x - from.x) * (i + 1)) / steps,
+        y: from.y,
+      })),
+      { type: 'pointerup', x: to.x, y: to.y },
+    ])
+    await expectMirrorSelection(page, 1, 5)
+  })
+
+  test('should hand a touch long-press over to the native selection UI', async ({
+    page,
+  }) => {
+    const input = page.getByRole('textbox')
+    await input.pressSequentially('123456')
+    await expectMirrorSelection(page, 5, 6)
+
+    const c1 = await slotCenter(page, 1)
+    await dispatchTouch(page, [{ type: 'pointerdown', x: c1.x, y: c1.y }])
+    // Held still past the long-press threshold: the gesture now belongs to
+    // the native loupe/edit-menu, so later movements and the release must
+    // not touch the selection
+    await page.waitForTimeout(500)
+    const c3 = await slotCenter(page, 3)
+    await dispatchTouch(page, [
+      { type: 'pointermove', x: c3.x, y: c3.y },
+      { type: 'pointerup', x: c3.x, y: c3.y },
+    ])
+    await page.waitForTimeout(100)
+    await expectMirrorSelection(page, 5, 6)
+  })
+
+  test('should keep a touch-selected range when tapping inside it', async ({
+    page,
+  }) => {
+    const input = page.getByRole('textbox')
+    await input.pressSequentially('123456')
+
+    // Drag-select slots 1..4 via touch
+    const from = await slotCenter(page, 1)
+    const to = await slotCenter(page, 4)
+    const steps = 5
+    await dispatchTouch(page, [
+      { type: 'pointerdown', x: from.x, y: from.y },
+      ...Array.from({ length: steps }, (_, i) => ({
+        type: 'pointermove',
+        x: from.x + ((to.x - from.x) * (i + 1)) / steps,
+        y: from.y,
+      })),
+      { type: 'pointerup', x: to.x, y: to.y },
+    ])
+    await expectMirrorSelection(page, 1, 5)
+
+    // Tapping inside the range keeps it — this is the gesture iOS uses to
+    // present the edit menu over a selection, so collapsing it here would
+    // make copy/cut/paste unreachable after a drag-select
+    const inside = await slotCenter(page, 2)
+    await dispatchTouch(page, [
+      { type: 'pointerdown', x: inside.x, y: inside.y },
+      { type: 'pointerup', x: inside.x, y: inside.y },
+    ])
+    await page.waitForTimeout(100)
+    await expectMirrorSelection(page, 1, 5)
+
+    // Tapping outside the range still selects the tapped slot
+    const outside = await slotCenter(page, 5)
+    await dispatchTouch(page, [
+      { type: 'pointerdown', x: outside.x, y: outside.y },
+      { type: 'pointerup', x: outside.x, y: outside.y },
+    ])
+    await expectMirrorSelection(page, 5, 6)
+  })
+
+  test('should hand over when the selection moves natively during a still touch hold', async ({
+    page,
+  }) => {
+    const input = page.getByRole('textbox')
+    await input.pressSequentially('123456')
+    await expectMirrorSelection(page, 5, 6)
+
+    const c1 = await slotCenter(page, 1)
+    await dispatchTouch(page, [{ type: 'pointerdown', x: c1.x, y: c1.y }])
+
+    // Before the long-press threshold, the platform's long-press machinery
+    // (iOS caret loupe) can engage and move the caret on its own. The
+    // gesture must yield to it instead of re-asserting the tapped slot.
+    await page.waitForTimeout(150)
+    await input.evaluate(el => {
+      ;(el as HTMLInputElement).setSelectionRange(3, 3)
+      document.dispatchEvent(new Event('selectionchange'))
+    })
+    // The mid-text caret goes through the regular caret→slot remap
+    // (previous selection was 5,6 so the caret at 3 selects slot 2)
+    await expectMirrorSelection(page, 2, 3)
+
+    // Releasing must not apply the originally tapped slot
+    await dispatchTouch(page, [{ type: 'pointerup', x: c1.x, y: c1.y }])
+    await page.waitForTimeout(100)
+    await expectMirrorSelection(page, 2, 3)
+  })
+
+  test('should leave the selection untouched when a touch gesture is canceled', async ({
+    page,
+  }) => {
+    const input = page.getByRole('textbox')
+    await input.pressSequentially('123456')
+    await expectMirrorSelection(page, 5, 6)
+
+    const c = await slotCenter(page, 1)
+    // A vertical swipe starting on the input turns into a scroll: the
+    // browser sends pointercancel and the selection must not move
+    await dispatchTouch(page, [
+      { type: 'pointerdown', x: c.x, y: c.y },
+      { type: 'pointercancel', x: c.x, y: c.y + 30 },
+      { type: 'pointerup', x: c.x, y: c.y + 30 },
+    ])
+    await page.waitForTimeout(100)
+    await expectMirrorSelection(page, 5, 6)
+  })
+
+  test('should select the tapped slot on real touchscreens', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      !(testInfo.project.use as { hasTouch?: boolean }).hasTouch,
+      'requires a touch-enabled project',
+    )
+    const input = page.getByRole('textbox')
+    await input.pressSequentially('123456')
+
+    const c = await slotCenter(page, 2)
+    await page.touchscreen.tap(c.x, c.y)
+    await expectMirrorSelection(page, 2, 3)
+  })
+})
+
+test.describe('Base tests - Pointer Shift Selections', () => {
+  test.skip(
+    process.env.CI === 'true',
+    'Breaks in CI as it cannot handle Shift key',
+  )
+
+  test('should extend the selection with shift-click', async ({ page }) => {
+    const input = page.getByRole('textbox')
+    await input.pressSequentially('123456')
+
+    const c1 = await slotCenter(page, 1)
+    await page.mouse.click(c1.x, c1.y)
+    await expectMirrorSelection(page, 1, 2)
+
+    const c4 = await slotCenter(page, 4)
+    await page.keyboard.down('Shift')
+    await page.mouse.click(c4.x, c4.y)
+    await page.keyboard.up('Shift')
+    await expectMirrorSelection(page, 1, 5)
+  })
+})

--- a/packages/input-otp/src/input.tsx
+++ b/packages/input-otp/src/input.tsx
@@ -6,6 +6,7 @@ import { syncTimeouts } from './sync-timeouts'
 import { OTPInputProps, RenderProps } from './types'
 import { usePrevious } from './use-previous'
 import { usePasswordManagerBadge } from './use-pwm-badge'
+import { useSlotSelection } from './use-slot-selection'
 
 export const OTPInputContext = React.createContext<RenderProps>(
   {} as RenderProps,
@@ -110,6 +111,14 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
         if (document.activeElement !== input) {
           setMirrorSelectionStart(null)
           setMirrorSelectionEnd(null)
+          return
+        }
+
+        // A pointer gesture in progress owns the selection: re-assert its
+        // intended range when a competing native caret placement (the
+        // tap's default action, which lands after our pointer handlers)
+        // tries to move it. No-op outside a gesture window.
+        if (slotSelection.enforceSelection(input)) {
           return
         }
 
@@ -405,9 +414,24 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
       isFocused,
     })
 
+    // Tap/click a slot to select it, drag to select a range. Mouse-only
+    // behaviors are re-implemented on top of prevented native defaults;
+    // touch cooperates with the native gestures (scroll, iOS/Android
+    // long-press menus) instead of preventing them.
+    const slotSelection = useSlotSelection({
+      inputRef,
+      containerRef,
+      maxLength,
+      inputMetadataRef,
+      setMirrorSelectionStart,
+      setMirrorSelectionEnd,
+    })
+
     /** Event handlers */
     const _changeListener = React.useCallback(
       (e: React.ChangeEvent<HTMLInputElement>) => {
+        // Typing ends any pointer interaction with the selection
+        slotSelection.clearGesture()
         const newValue = e.currentTarget.value.slice(0, maxLength)
         if (newValue.length > 0 && regexp && !regexp.test(newValue)) {
           e.preventDefault()
@@ -425,10 +449,12 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
         }
         onChange(newValue)
       },
-      [maxLength, onChange, previousValue, regexp],
+      [maxLength, onChange, previousValue, regexp, slotSelection],
     )
     const _focusListener = React.useCallback(() => {
-      if (inputRef.current) {
+      // A pointer gesture reaching focus supplies the selection itself
+      // (the tapped slot / dragged range) instead of the default below
+      if (inputRef.current && !slotSelection.applySelectionOnFocus()) {
         const start = Math.min(inputRef.current.value.length, maxLength - 1)
         const end = inputRef.current.value.length
         inputRef.current?.setSelectionRange(start, end)
@@ -436,7 +462,7 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
         setMirrorSelectionEnd(end)
       }
       setIsFocused(true)
-    }, [maxLength])
+    }, [maxLength, slotSelection])
     // Fix iOS pasting
     const _pasteListener = React.useCallback(
       (e: React.ClipboardEvent<HTMLInputElement>) => {
@@ -451,6 +477,9 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
         const _content = e.clipboardData.getData('text/plain')
         const content = pasteTransformer ? pasteTransformer(_content) : _content
         e.preventDefault()
+
+        // Pasting replaces the selection — the gesture must not restore it
+        slotSelection.clearGesture()
 
         const start = inputRef.current?.selectionStart
         const end = inputRef.current?.selectionEnd
@@ -476,7 +505,7 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
         setMirrorSelectionStart(_start)
         setMirrorSelectionEnd(_end)
       },
-      [maxLength, onChange, pasteTransformer, regexp, value],
+      [maxLength, onChange, pasteTransformer, regexp, slotSelection, value],
     )
 
     /** Styles */
@@ -507,6 +536,10 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
         opacity: '1', // Mandatory for iOS hold-paste
         color: 'transparent',
         pointerEvents: 'all',
+        // Keep vertical page scrolling native while horizontal drags feed
+        // the slot-selection gesture (also disables double-tap zoom, so
+        // consecutive taps on slots don't zoom the page).
+        touchAction: 'pan-y',
         background: 'transparent',
         caretColor: 'transparent',
         border: '0 solid transparent',
@@ -567,11 +600,32 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
             setIsHoveringInput(false)
             props.onMouseLeave?.(e)
           }}
+          onPointerDown={e => {
+            slotSelection.onPointerDown(e)
+            props.onPointerDown?.(e)
+          }}
+          onPointerMove={e => {
+            slotSelection.onPointerMove(e)
+            props.onPointerMove?.(e)
+          }}
+          onPointerUp={e => {
+            slotSelection.onPointerUp(e)
+            props.onPointerUp?.(e)
+          }}
+          onPointerCancel={e => {
+            slotSelection.onPointerCancel(e)
+            props.onPointerCancel?.(e)
+          }}
+          onMouseDown={e => {
+            slotSelection.onMouseDown(e)
+            props.onMouseDown?.(e)
+          }}
           onFocus={e => {
             _focusListener()
             props.onFocus?.(e)
           }}
           onBlur={e => {
+            slotSelection.clearGesture()
             setIsFocused(false)
             props.onBlur?.(e)
           }}
@@ -589,6 +643,7 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
         placeholder,
         props,
         regexp?.source,
+        slotSelection,
         value,
       ],
     )

--- a/packages/input-otp/src/use-slot-selection.ts
+++ b/packages/input-otp/src/use-slot-selection.ts
@@ -1,0 +1,508 @@
+import * as React from 'react'
+
+type SelectionDirection = 'none' | 'forward' | 'backward'
+/** [selectionStart, selectionEnd, selectionDirection] */
+type Selection = [number, number, SelectionDirection]
+
+interface SlotCenter {
+  x: number
+  y: number
+}
+
+interface Gesture {
+  pointerId: number
+  pointerType: string
+  downAt: number
+  downX: number
+  downY: number
+  /** Rendered slot centers, measured once at pointerdown (client coords). */
+  centers: SlotCenter[]
+  /** Slot index where the gesture started — ranges extend from here. */
+  anchor: number
+  lastSlot: number
+  moved: boolean
+  /** Pointer still down and the gesture not handed over to the native UI. */
+  active: boolean
+  upAt: number | null
+  /** The selection this gesture wants the input to have right now. */
+  intended: Selection
+}
+
+/** A touch held still longer than this belongs to the native long-press UI
+ *  (iOS caret loupe + edit menu, Android selection handles). Past this point
+ *  the gesture is abandoned entirely — no selection is applied and nothing
+ *  is enforced — so the native menus present exactly as they would without
+ *  this feature. Kept below the ~500ms the platforms need to trigger their
+ *  long-press recognizers. */
+const LONG_PRESS_MS = 400
+
+/** Mobile browsers place the caret natively as part of the tap's default
+ *  action, which lands *after* our pointerup handler applied the tapped
+ *  slot. Keep re-asserting the intended range for a short window so that
+ *  native caret placement cannot undo the tap. Must stay well below the
+ *  time it takes to reach any edit-menu action (e.g. Select All), which
+ *  must not be fought. */
+const POST_UP_ENFORCE_MS = 250
+
+/** Finger taps wobble by a few px — don't promote a wobbly tap to a drag. */
+const TOUCH_SLOP_PX = 8
+const MOUSE_SLOP_PX = 2
+
+/** PointerEvent.detail is unreliable for click counts, so double-clicks are
+ *  detected manually from two nearby pointerdowns. */
+const DOUBLE_CLICK_MS = 400
+const DOUBLE_CLICK_SLOP_PX = 8
+
+/** Custom renderers can tag each slot element with `data-input-otp-slot`
+ *  for exact pointer→slot hit mapping. shadcn/ui's `data-slot` convention
+ *  is picked up automatically. Without tags, the container width is split
+ *  evenly — exact for uniform slots, approximate around separators. */
+const SLOT_SELECTOR = '[data-input-otp-slot], [data-slot="input-otp-slot"]'
+
+function measureSlotCenters(
+  container: HTMLElement,
+  maxLength: number,
+): SlotCenter[] {
+  const els = container.querySelectorAll(SLOT_SELECTOR)
+  if (els.length === maxLength) {
+    return Array.prototype.map.call(els, (el: Element) => {
+      const r = el.getBoundingClientRect()
+      return { x: r.left + r.width / 2, y: r.top + r.height / 2 }
+    }) as SlotCenter[]
+  }
+
+  const rect = container.getBoundingClientRect()
+  const isRTL = getComputedStyle(container).direction === 'rtl'
+  return Array.from({ length: maxLength }, (_, i) => {
+    const visualIdx = isRTL ? maxLength - 1 - i : i
+    return {
+      x: rect.left + ((visualIdx + 0.5) * rect.width) / maxLength,
+      y: rect.top + rect.height / 2,
+    }
+  })
+}
+
+function nearestSlot(centers: SlotCenter[], x: number, y: number): number {
+  let best = 0
+  let bestDist = Infinity
+  for (let i = 0; i < centers.length; i++) {
+    const dx = centers[i].x - x
+    const dy = centers[i].y - y
+    const dist = dx * dx + dy * dy
+    if (dist < bestDist) {
+      bestDist = dist
+      best = i
+    }
+  }
+  return best
+}
+
+function selectionForTap(
+  slot: number,
+  valueLength: number,
+  maxLength: number,
+): Selection {
+  if (valueLength === 0) {
+    return [0, 0, 'none']
+  }
+  if (slot >= valueLength) {
+    // Tapped an empty slot: park the caret at the end in insert mode
+    // (a full input never reaches here — every slot holds a char).
+    return valueLength === maxLength
+      ? [valueLength - 1, valueLength, 'backward']
+      : [valueLength, valueLength, 'none']
+  }
+  return [slot, slot + 1, 'forward']
+}
+
+function selectionForDrag(
+  anchor: number,
+  slot: number,
+  valueLength: number,
+): Selection {
+  if (valueLength === 0) {
+    return [0, 0, 'none']
+  }
+  const lo = Math.min(anchor, slot)
+  const hi = Math.max(anchor, slot)
+  if (lo >= valueLength) {
+    // The whole drag happened past the typed chars
+    return [valueLength, valueLength, 'none']
+  }
+  return [
+    lo,
+    Math.min(hi + 1, valueLength),
+    slot < anchor ? 'backward' : 'forward',
+  ]
+}
+
+/**
+ * Maps pointer gestures onto slot selections: tapping/clicking a slot
+ * selects it, dragging extends the selection across slots — the behavior a
+ * user expects from a segmented input, which the invisible input cannot
+ * provide natively because its text geometry has nothing to do with the
+ * rendered slots.
+ *
+ * Mouse pointers are handled eagerly (native selection is prevented and
+ * fully re-implemented). Touch pointers are handled cooperatively: native
+ * defaults are never prevented, so focus, scrolling (via `touch-action:
+ * pan-y`) and — critically — the iOS/Android long-press UIs keep working;
+ * the intended slot selection is applied at the moments the platform allows
+ * and briefly re-asserted when the native caret placement races it.
+ */
+export function useSlotSelection({
+  inputRef,
+  containerRef,
+  maxLength,
+  inputMetadataRef,
+  setMirrorSelectionStart,
+  setMirrorSelectionEnd,
+}: {
+  inputRef: React.RefObject<HTMLInputElement>
+  containerRef: React.RefObject<HTMLDivElement>
+  maxLength: number
+  inputMetadataRef: React.MutableRefObject<{
+    prev: [number | null, number | null, 'none' | 'forward' | 'backward']
+  }>
+  setMirrorSelectionStart: (value: number | null) => void
+  setMirrorSelectionEnd: (value: number | null) => void
+}) {
+  const gestureRef = React.useRef<Gesture | null>(null)
+  const lastMouseDownRef = React.useRef<{ at: number; x: number } | null>(null)
+
+  const clearGesture = React.useCallback(() => {
+    gestureRef.current = null
+  }, [])
+
+  /** Returns the gesture if it should still control the selection,
+   *  clearing it lazily once its window has passed. */
+  const liveGesture = React.useCallback((): Gesture | null => {
+    const gesture = gestureRef.current
+    if (!gesture) {
+      return null
+    }
+    const now = Date.now()
+    const expired =
+      gesture.upAt !== null
+        ? now - gesture.upAt > POST_UP_ENFORCE_MS
+        : gesture.pointerType !== 'mouse' &&
+          !gesture.moved &&
+          now - gesture.downAt > LONG_PRESS_MS
+    if (expired) {
+      gestureRef.current = null
+      return null
+    }
+    return gesture
+  }, [])
+
+  const applySelection = React.useCallback(
+    (selection: Selection) => {
+      const input = inputRef.current
+      if (!input) {
+        return
+      }
+      if (gestureRef.current) {
+        gestureRef.current.intended = selection
+      }
+      if (
+        input.selectionStart !== selection[0] ||
+        input.selectionEnd !== selection[1]
+      ) {
+        input.setSelectionRange(selection[0], selection[1], selection[2])
+      }
+      setMirrorSelectionStart(selection[0])
+      setMirrorSelectionEnd(selection[1])
+      inputMetadataRef.current.prev = [selection[0], selection[1], selection[2]]
+    },
+    [
+      inputRef,
+      inputMetadataRef,
+      setMirrorSelectionStart,
+      setMirrorSelectionEnd,
+    ],
+  )
+
+  /** Called by the focus listener. Returns true when a pointer gesture
+   *  supplied the initial selection (tap-to-focus lands on the tapped slot
+   *  instead of the default end-of-value selection). */
+  const applySelectionOnFocus = React.useCallback((): boolean => {
+    const gesture = liveGesture()
+    if (!gesture) {
+      return false
+    }
+    applySelection(gesture.intended)
+    return true
+  }, [applySelection, liveGesture])
+
+  /** Called by the document selectionchange handler. Returns true when the
+   *  gesture's intended selection was re-asserted over a competing native
+   *  caret placement (the browser moves the caret at tap-end, after our
+   *  handlers already ran). */
+  const enforceSelection = React.useCallback(
+    (input: HTMLInputElement): boolean => {
+      const gesture = liveGesture()
+      if (!gesture) {
+        return false
+      }
+      const [start, end] = gesture.intended
+      if (input.selectionStart === start && input.selectionEnd === end) {
+        return false
+      }
+      if (
+        gesture.pointerType !== 'mouse' &&
+        !gesture.moved &&
+        gesture.upAt === null
+      ) {
+        // A still-held touch has applied nothing yet, so a selection that
+        // moved on its own here is the platform's long-press machinery
+        // engaging (iOS caret loupe, Android handles) — which can happen
+        // before the LONG_PRESS_MS cutoff. Hand the gesture over instead
+        // of fighting the very interaction the edit menu hangs off of.
+        gestureRef.current = null
+        return false
+      }
+      applySelection(gesture.intended)
+      return true
+    },
+    [applySelection, liveGesture],
+  )
+
+  const onPointerDown = React.useCallback(
+    (e: React.PointerEvent<HTMLInputElement>) => {
+      const container = containerRef.current
+      if (e.button !== 0 || !e.isPrimary || !container) {
+        return
+      }
+      const input = e.currentTarget
+      const valueLength = input.value.length
+      const centers = measureSlotCenters(container, maxLength)
+      const slot = nearestSlot(centers, e.clientX, e.clientY)
+      const isMouse = e.pointerType === 'mouse'
+
+      let anchor = slot
+      let intended = selectionForTap(slot, valueLength, maxLength)
+
+      if (!isMouse && document.activeElement === input) {
+        const selStart = input.selectionStart
+        const selEnd = input.selectionEnd
+        if (
+          selStart !== null &&
+          selEnd !== null &&
+          selEnd - selStart > 1 &&
+          slot >= selStart &&
+          slot < selEnd
+        ) {
+          // Tapping inside a multi-slot selection keeps it, matching the
+          // native "tap the selection to show the edit menu" gesture. This
+          // is the only route to copy/cut/paste after a drag-made range: a
+          // programmatic selection never auto-presents the menu, and the
+          // drag's movement has already defeated the long-press recognizer
+          // for that touch. Dragging still re-anchors from the tapped slot.
+          intended = [selStart, selEnd, input.selectionDirection ?? 'none']
+        }
+      }
+
+      if (isMouse) {
+        const now = Date.now()
+        const prev = inputMetadataRef.current.prev
+        const lastDown = lastMouseDownRef.current
+        lastMouseDownRef.current = { at: now, x: e.clientX }
+
+        if (
+          e.shiftKey &&
+          document.activeElement === input &&
+          prev[0] !== null &&
+          prev[1] !== null
+        ) {
+          // Shift-click extends the current selection, like a text field
+          anchor = slot >= prev[0] ? prev[0] : Math.max(0, prev[1] - 1)
+          intended = selectionForDrag(anchor, slot, valueLength)
+        } else if (
+          lastDown &&
+          now - lastDown.at < DOUBLE_CLICK_MS &&
+          Math.abs(e.clientX - lastDown.x) <= DOUBLE_CLICK_SLOP_PX &&
+          valueLength > 0
+        ) {
+          intended = [0, valueLength, 'forward']
+        }
+      }
+
+      gestureRef.current = {
+        pointerId: e.pointerId,
+        pointerType: e.pointerType,
+        downAt: Date.now(),
+        downX: e.clientX,
+        downY: e.clientY,
+        centers,
+        anchor,
+        lastSlot: slot,
+        moved: false,
+        active: true,
+        upAt: null,
+        intended,
+      }
+
+      if (isMouse) {
+        // Suppress the native mousedown defaults (focus + text-selection
+        // drag over the invisible text) and re-implement them: focus stays
+        // but the selection maps to slots. Touch is left untouched so
+        // native focus, scrolling and long-press menus keep working.
+        e.preventDefault()
+        try {
+          input.setPointerCapture(e.pointerId)
+        } catch {
+          // Losing capture only means the drag stops updating once the
+          // pointer leaves the input — never worth throwing for.
+        }
+        if (document.activeElement !== input) {
+          input.focus()
+        } else {
+          applySelection(intended)
+        }
+      }
+    },
+    [applySelection, containerRef, inputMetadataRef, maxLength],
+  )
+
+  // Backup for browsers where canceling pointerdown does not suppress the
+  // compatibility mousedown's default actions (focus + selection drag).
+  const onMouseDown = React.useCallback(
+    (e: React.MouseEvent<HTMLInputElement>) => {
+      const gesture = gestureRef.current
+      if (gesture && gesture.active && gesture.pointerType === 'mouse') {
+        e.preventDefault()
+      }
+    },
+    [],
+  )
+
+  const onPointerMove = React.useCallback(
+    (e: React.PointerEvent<HTMLInputElement>) => {
+      const gesture = gestureRef.current
+      if (!gesture || !gesture.active || e.pointerId !== gesture.pointerId) {
+        return
+      }
+      const input = e.currentTarget
+
+      if (!gesture.moved) {
+        const slop =
+          gesture.pointerType === 'mouse' ? MOUSE_SLOP_PX : TOUCH_SLOP_PX
+        const dx = e.clientX - gesture.downX
+        const dy = e.clientY - gesture.downY
+        if (dx * dx + dy * dy < slop * slop) {
+          return
+        }
+        if (
+          gesture.pointerType !== 'mouse' &&
+          Date.now() - gesture.downAt > LONG_PRESS_MS
+        ) {
+          // First movement only after the long-press threshold: this is
+          // the native caret loupe / selection-handle drag, not a slot
+          // drag. Hand the gesture over untouched.
+          gestureRef.current = null
+          return
+        }
+        gesture.moved = true
+        if (document.activeElement !== input) {
+          // A touch drag never produces the click that would focus the
+          // input natively — claim focus so the selection is visible.
+          input.focus()
+        }
+      }
+
+      const slot = nearestSlot(gesture.centers, e.clientX, e.clientY)
+      if (slot === gesture.lastSlot) {
+        return
+      }
+      gesture.lastSlot = slot
+      const selection = selectionForDrag(
+        gesture.anchor,
+        slot,
+        input.value.length,
+      )
+      if (document.activeElement === input) {
+        applySelection(selection)
+      } else {
+        // Focus was refused (possible on iOS outside a tap) — remember the
+        // range so the focus listener can apply it when focus arrives.
+        gesture.intended = selection
+      }
+    },
+    [applySelection],
+  )
+
+  const onPointerUp = React.useCallback(
+    (e: React.PointerEvent<HTMLInputElement>) => {
+      const gesture = gestureRef.current
+      if (!gesture || e.pointerId !== gesture.pointerId) {
+        return
+      }
+      const input = e.currentTarget
+
+      if (gesture.pointerType === 'mouse') {
+        // Native defaults were prevented, so there is nothing to enforce
+        // after release.
+        gestureRef.current = null
+        return
+      }
+
+      const now = Date.now()
+      if (!gesture.moved && now - gesture.downAt > LONG_PRESS_MS) {
+        // Long-press release: the native edit menu is presenting — leave
+        // the selection exactly where the platform put it.
+        gestureRef.current = null
+        return
+      }
+
+      gesture.active = false
+      gesture.upAt = now
+      if (document.activeElement === input) {
+        // Tap: select the tapped slot. Selection is deferred to release on
+        // touch so that a scroll starting on the input never moves it.
+        applySelection(gesture.intended)
+      } else if (gesture.moved) {
+        // Drag on an unfocused input: no native click → no native focus.
+        // The focus listener applies the dragged range.
+        input.focus()
+      }
+      // Tap on an unfocused input: the native click focuses it right after
+      // this event, and the focus listener applies the tapped slot.
+    },
+    [applySelection],
+  )
+
+  const onPointerCancel = React.useCallback(
+    (e: React.PointerEvent<HTMLInputElement>) => {
+      const gesture = gestureRef.current
+      if (gesture && e.pointerId === gesture.pointerId) {
+        // The browser claimed the gesture (scroll) — nothing was applied
+        // for touch taps yet, so bailing out leaves no trace.
+        gestureRef.current = null
+      }
+    },
+    [],
+  )
+
+  return React.useMemo(
+    () => ({
+      onPointerDown,
+      onPointerMove,
+      onPointerUp,
+      onPointerCancel,
+      onMouseDown,
+      applySelectionOnFocus,
+      enforceSelection,
+      clearGesture,
+    }),
+    [
+      onPointerDown,
+      onPointerMove,
+      onPointerUp,
+      onPointerCancel,
+      onMouseDown,
+      applySelectionOnFocus,
+      enforceSelection,
+      clearGesture,
+    ],
+  )
+}


### PR DESCRIPTION
## What

Pointer gestures now map onto the rendered slots, on desktop and mobile:

- **Click/tap a slot** selects it (tapping past the filled slots parks the caret at the end, in insert mode).
- **Drag** extends the selection across slots, clamped to the typed chars; works right-to-left too.
- **Double-click** selects all; **shift-click** extends the selection (mouse).
- Typing into a selection replaces it, as with any text field.

Implemented in a new `use-slot-selection.ts` hook wired into `input.tsx`.

## Why

The invisible input's text geometry (collapsed letter-spacing, transparent text) has nothing to do with the slot boxes users see, so native caret placement could never reach the slot under the pointer — clicking a slot was effectively random, and selecting a range with the pointer was impossible.

## How it stays compatible with the native touch UX

- **Nothing is prevented on touch.** Mouse gestures suppress native defaults and re-implement them; touch cooperates instead, so native focus, scrolling (`touch-action: pan-y` — vertical swipes still scroll the page) and the iOS/Android long-press menus keep working.
- **Long-press is handed over.** A touch held still past ~400ms belongs to the platform (iOS caret loupe + edit menu, Android handles) and the gesture is abandoned untouched. If the selection moves natively *before* that cutoff (the loupe can engage at ~330ms), the gesture yields immediately — the handover is selection-driven, not just timer-driven.
- **Tapping inside a multi-slot selection keeps it**, matching the native "tap the selection to show the edit menu" gesture. That's the only route to copy/cut/paste after a drag-made range: WebKit never auto-presents the menu for programmatic selections, and the drag's movement has already defeated the long-press recognizer for that touch.
- **Touch applies the selection on release**, so a scroll starting on the input never moves it (`pointercancel` bails out cleanly).

## Slot hit-mapping

Elements tagged `data-input-otp-slot` (or shadcn/ui's `data-slot="input-otp-slot"`, detected automatically) give exact pointer→slot mapping. Untagged renderers fall back to splitting the container width evenly — exact for uniform slots, approximate around separators. Documented in the README.

## Testing

- New `base.pointer-selections.spec.ts`: 16 tests covering click, drag (both directions, clamping, unfocused), double-click, shift-click, touch taps/drags, long-press handover, native-selection handover, tap-inside-range, and pointercancel.
- Full suite: **177 passed** across Chromium, Firefox, WebKit, Mobile Chrome and Mobile Safari. `tsc --noEmit` clean.
- ⚠️ The iOS-specific paths (edit menu, caret loupe) can't be exercised in Playwright — the `-webkit-touch-callout` guard never matches in CI. Verified flows to re-check on a real device: tap-to-focus, tap a slot, drag a range, long-press → paste menu, and tap a drag-made range → Copy/Cut menu over it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)