### PR TITLE
fix(readme): unbreak the Rapidproxy sponsor image

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The accessible, unstyled, fully featured one-time-password component for React.
 </td>
 <td align="center">
 <a href="https://www.rapidproxy.io/?ref=inpu" target="_blank">
-<img alt="Rapidproxy" src="https://input-otp.rodz.dev/sponsors/rapidproxy-wordmark-white-in-black-bg.svg" width="110"/>
+<img alt="Rapidproxy" src="https://raw.githubusercontent.com/guilhermerodz/input-otp/8476b12529c0d82ae2615e1414de2702c1779fb3/apps/website/public/sponsors/rapidproxy-wordmark-white-in-black-bg.svg" width="110"/>
 </a>
 </td>
 </tr>


### PR DESCRIPTION
## What

The Rapidproxy README image pointed at `https://input-otp.rodz.dev/sponsors/…`, which 404s until the website redeploys with the new asset — so the README showed a broken image right after #135 merged (and GitHub's camo proxy can cache that 404 for a while).

This pins the image to `raw.githubusercontent.com/…/8476b12…/apps/website/public/sponsors/rapidproxy-wordmark-white-in-black-bg.svg`, which is verified live (HTTP 200) and keeps resolving regardless of website deploy state — on GitHub and on the npm page (the package README is copied from this one at publish).

The other sponsor images stay on the rodz.dev URLs — they're already deployed and loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)