### PR TITLE
docs(readme): list Rapidproxy in the Sponsors section footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ autofill and password manager badges **cannot** be covered headlessly — see
 - [Clerk](https://go.clerk.com/input-otp) — the easiest way to add authentication to your application
 - [Resend](https://go.resend.com/input-otp) — email for developers
 - [Evomi](https://evomi.com/?utm_source=github&utm_campaign=otp) — residential proxies from $0.49
+- [Rapidproxy](https://www.rapidproxy.io/?ref=inpu) — residential proxies from $0.55
 
 <br />
 


### PR DESCRIPTION
Follow-up to #135/#136: the `## Sponsors` list at the end of the README was missed when Rapidproxy was added to the hero table. Adds the matching line:

> [Rapidproxy](https://www.rapidproxy.io/?ref=inpu) — residential proxies from $0.55

🤖 Generated with [Claude Code](https://claude.com/claude-code)