### PR TITLE
fix(input): trial iOS selection workaround in 1.6 beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,19 @@
 # Changelog
 
-## [1.5.0-beta.0]
+## [1.5.0-beta.1]
 
+Everything that landed after 1.4.2, in one beta. (A 1.5.0-beta.0 was drafted along the way but never published to npm; its items are folded in below.)
+
+The headline: the iOS native selection artifact — the thin, caret-tall line documented as a known limitation in #32 and reported in #75/#110 — is gone.
+
+- fix(input): eliminate the iOS native selection artifact
+  - On iOS there is now nothing visible at rest, at any fill state or selection size. During a tap or long-press, at most a ~2px fleck renders under the fingertip while the gesture is active, and iOS's copy/paste menu keeps working.
+  - How: iOS paints the selection highlight in a native layer that ignores `::selection`, CSS `opacity`, and ancestor clipping — but it tracks the rendered text geometry. So the text is parked offscreen (`text-indent: -9999px`) and revealed at the pointer's position only during pointer gestures, because the copy/paste menu can only anchor to an on-screen caret/selection rect. Collapsed `letter-spacing` keeps the revealed artifact the same size whether 1 or 6 chars are selected, and `font-size: 16px` + `transform: scale(0.1)` (with a compensating 10x layout box, so the tap area still exactly matches the container) compresses it to iOS's ~2px minimum painting size without ever dipping below the 16px focus-zoom threshold — no page zoom, no `maximum-scale=1` required from apps.
+  - Drop-in: no API changes and no markup/CSS/viewport changes required. Non-iOS browsers are byte-identical (the `@supports (-webkit-touch-callout: none)` guard is false on Blink/Gecko/desktop WebKit). iPhone Chrome/Firefox/in-app browsers are WebKit and get the fix.
+  - If you patched the artifact yourself (e.g. `font-size: 16px !important`, custom transforms or `text-indent` on `[data-input-otp]`), remove those workarounds — overriding the input's geometry can now interfere with the fix.
+  - Note: on iOS 12 and older (no Pointer Events, ~0.1% share) the artifact is hidden but edit-menu anchoring is unavailable; typing, autofill and keyboard paste are unaffected.
+- chore(input): measure `--root-height` from the container instead of the input (same value in practice; the input's layout box is enlarged 10x on iOS)
+- chore(playground): add manual device-test pages `/ios-probe` (parameterized probe) and `/shadcn` (faithful reproduction of the shadcn/ui input-otp demo), since the iOS code path cannot be exercised by the Playwright suite
 - fix(input): reserve the password manager badge gutter only where it fits
   - Once a badge was detected, the input grew 40px past the container to push the badge off the last slot — and the only guard was the distance to the viewport's right edge. Inside a constrained scroll container (a card, a modal) that overhang registered as scrollable overflow: a horizontal scrollbar appeared and shifted the whole layout. The space check now measures the nearest ancestor that constrains horizontal overflow (scroll containers, `overflow: hidden`/`clip` ancestors, the container itself, and the real viewport width) and skips the push when the gutter doesn't fit; the badge then stays over the last slot, exactly as with `pushPasswordManagerStrategy="none"`. Nothing is ever clipped, so extensions keep rendering their badges.
 - fix(input): disable spellcheck by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.5.0]
+
+Promotes the safe 1.5.0-beta.2 code without functional changes. The experimental iOS native-selection workaround from 1.5.0-beta.1 is not included; the thin native selection artifact remains a known cosmetic limitation.
+
+- fix(input): reserve the password manager badge gutter only where it fits
+- fix(input): disable spellcheck by default
+- fix(input): feature-detect `ResizeObserver` before observing
+- fix(input): use a 16px fallback until `--root-height` resolves, preventing iOS focus zoom
+- fix(input): clear pending synchronization timeouts on unmount
+- feat(input): add a `nonce` prop for Content-Security-Policy support
+- fix(input): guard the input reference used by the `selectionchange` listener
+- fix(input): opt the container out of browser translation
+- fix(input): report cosmetic CSS rule failures as warnings instead of errors
+- chore(types): narrow `onComplete` to `(value: string) => unknown`
+- docs: document the stable iOS selection behavior and its cosmetic limitation
+
 ## [1.5.0-beta.2]
 
 Safe release candidate for 1.5.0. This release withdraws the experimental iOS native-selection workaround from 1.5.0-beta.1 after compatibility review. The edit menu, paste, typing, selection and focus behavior return to the proven 1.4.x implementation; the thin native selection artifact remains a known iOS limitation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
+## [1.5.0-beta.2]
+
+Safe release candidate for 1.5.0. This release withdraws the experimental iOS native-selection workaround from 1.5.0-beta.1 after compatibility review. The edit menu, paste, typing, selection and focus behavior return to the proven 1.4.x implementation; the thin native selection artifact remains a known iOS limitation.
+
+- revert(input): withdraw the experimental iOS native-selection workaround from 1.5.0-beta.1
+- docs: align the mobile and edge-case documentation with the stable candidate
+- test: verify focus, typing, editing, deletion, paste, Select All → Paste and the native edit menu on iOS 18.0 and 26.5 simulators
+
+## [1.5.0-beta.1]
+
+Deprecated experimental release. It introduced an iOS native-selection workaround that moved and scaled the underlying input. The workaround was withdrawn in 1.5.0-beta.2 and is not planned for 1.5.0 stable. Existing installs remain reproducible, but new beta users should use 1.5.0-beta.2 or later.
+
 ## [1.5.0-beta.0]
+
+Prepared but not published. Its safe changes are included in 1.5.0-beta.2.
 
 - fix(input): reserve the password manager badge gutter only where it fits
   - Once a badge was detected, the input grew 40px past the container to push the badge off the last slot — and the only guard was the distance to the viewport's right edge. Inside a constrained scroll container (a card, a modal) that overhang registered as scrollable overflow: a horizontal scrollbar appeared and shifted the whole layout. The space check now measures the nearest ancestor that constrains horizontal overflow (scroll containers, `overflow: hidden`/`clip` ancestors, the container itself, and the real viewport width) and skips the push when the gutter doesn't fit; the badge then stays over the last slot, exactly as with `pushPasswordManagerStrategy="none"`. Nothing is ever clipped, so extensions keep rendering their badges.
@@ -22,8 +36,6 @@
   - Some environments reject individual cosmetic selectors (`:autofill` in older Android WebViews, for instance). Nothing breaks when that happens, but the `console.error` was captured by Sentry and similar tools as if the application had failed. Same message, warning level.
 - chore(types): narrow `onComplete` to `(value: string) => unknown`
   - The declaration was a variadic `(...args: any[]) => unknown`, but the only call site has always passed a single string. Handlers declaring extra parameters (which could never receive values) now fail to compile; every zero-arg or `(code: string)` handler keeps compiling unchanged.
-
-Beta while the iOS fix soaks on real devices. Verified so far on iOS 26.5 (Simulator + manual pass): no artifact at rest, no focus zoom, tap-to-focus, edit menu via double-tap and long-press, paste into full and empty inputs, typing. Still being validated across iOS versions before stable: Select All → Paste from the edit menu, SMS AutoFill from Messages, type-over-when-full, RTL, and iPadOS (Scribble, pointer).
 
 ## [1.4.2]
 
@@ -99,7 +111,7 @@ I'm sorry to skip `1.3.0` due to an issue I've had while publishing the NPM pack
 - fix(input): reinforce wrapper to pointerEvents none
 - feat(input): add experimental push pwm badge
 - chore(input): rename prop to pushPasswordManagerStrategy
-- chore(input): move focus logic to _focusListener
+- chore(input): move focus logic to \_focusListener
 - fix(input): reinforce no box shadows
 - perf(input): rewrite core in a single event listener
 - fix(input): safe insert css rules

--- a/apps/playground/src/app/ios-probe/page.tsx
+++ b/apps/playground/src/app/ios-probe/page.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import * as React from 'react'
+
+import { OTPInput } from 'input-otp'
+
+// Manual probe page for the iOS-only native selection artifact (issues #32,
+// #75, #110). Playwright never exercises the iOS branch (the
+// -webkit-touch-callout guard only matches on iOS WebKit), so this page
+// exists to be opened in an iOS Simulator / real device.
+// Append ?legacy=1 to reproduce the pre-fix behavior (font-size equal to
+// --root-height) for a before/after comparison.
+const VARIANTS: Record<string, string> = {
+  // Pre-fix behavior: font-size equal to --root-height.
+  legacy: `[data-input-otp] { font-size: var(--root-height) !important; }`,
+  // Control: below the 16px threshold — expected to trigger iOS focus zoom.
+  tiny: `[data-input-otp] { font-size: 8px !important; }`,
+  // Ultra-small experiment: computed font-size stays 16px (no focus zoom),
+  // but the rendering is scaled down so the selection artifact becomes
+  // sub-2px. The layout box is enlarged by the inverse scale so the hit
+  // area still covers the container. Letter-spacing is relaxed so the
+  // *rendered* selection width stays >=1px (the touch callout constraint).
+  scale: `[data-input-otp] {
+    font-size: 16px !important;
+    width: 1000% !important;
+    height: 1000% !important;
+    transform: scale(0.1) !important;
+    transform-origin: 0 0 !important;
+    letter-spacing: .2em !important;
+    left: 0 !important;
+    right: 0 !important;
+  }`,
+}
+
+export default function Page() {
+  const ref = React.useRef<HTMLInputElement>(null)
+  const [variant, setVariant] = React.useState('fixed')
+  const [defaultValue, setDefaultValue] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    setDefaultValue(params.get('value') ?? '123456')
+
+    const v = params.get('variant') ?? (params.get('legacy') === '1' ? 'legacy' : null)
+    // Free-form CSS overrides for quick experiments:
+    // ?css=opacity:.1 scopes to the input; ?rawcss=<full rules> is verbatim.
+    const extraCss = params.get('css')
+    const rawCss = params.get('rawcss')
+    const override = [
+      v && VARIANTS[v] ? VARIANTS[v] : '',
+      extraCss
+        ? `[data-input-otp] { ${extraCss
+            .split(';')
+            .filter(d => d.trim())
+            .map(d => `${d} !important`)
+            .join('; ')}; }`
+        : '',
+      rawCss ?? '',
+    ]
+      .filter(Boolean)
+      .join('\n')
+    if (v && VARIANTS[v]) {
+      setVariant(v)
+    } else if (extraCss) {
+      setVariant(`css: ${extraCss}`)
+    }
+    if (!override) {
+      return
+    }
+    // Injected after the library's own stylesheet so it wins the cascade.
+    const t = setTimeout(() => {
+      const style = document.createElement('style')
+      style.innerHTML = `@supports (-webkit-touch-callout: none) { ${override} }`
+      document.head.appendChild(style)
+    }, 300)
+    return () => clearTimeout(t)
+  }, [])
+
+  React.useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('nofocus') === '1') {
+      return
+    }
+    const selectAll = params.get('selectall') === '1'
+    const t = setTimeout(() => {
+      ref.current?.focus()
+      if (selectAll) {
+        setTimeout(() => ref.current?.setSelectionRange(0, ref.current.value.length), 300)
+      }
+    }, 800)
+    return () => clearTimeout(t)
+  }, [])
+
+  // Tap-coordinate readout so screenshots can calibrate host->device mapping.
+  const [tap, setTap] = React.useState('none')
+  const tapCount = React.useRef(0)
+  React.useEffect(() => {
+    const onPointerDown = (e: PointerEvent) => {
+      tapCount.current += 1
+      setTap(
+        `#${tapCount.current} ${Math.round(e.clientX)},${Math.round(e.clientY)}`,
+      )
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => document.removeEventListener('pointerdown', onPointerDown)
+  }, [])
+
+  return (
+    <div
+      style={{
+        padding: 40,
+        background: 'white',
+        minHeight: '100vh',
+        fontFamily: 'sans-serif',
+      }}
+    >
+      <p data-testid="probe-mode">
+        variant: {variant} · tap: {tap}
+      </p>
+      {defaultValue === null ? null : (
+      <OTPInput
+        ref={ref}
+        maxLength={6}
+        defaultValue={defaultValue}
+        render={({ slots }) => (
+          <div style={{ display: 'flex', gap: 8 }}>
+            {slots.map((slot, idx) => (
+              <div
+                key={idx}
+                style={{
+                  width: 40,
+                  height: 56,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  background: 'white',
+                  border: '1px solid #ddd',
+                  borderRadius: 6,
+                  fontSize: 20,
+                  color: '#111',
+                  outline: slot.isActive ? '2px solid #bbb' : 'none',
+                }}
+              >
+                {slot.char}
+              </div>
+            ))}
+          </div>
+        )}
+      />
+      )}
+    </div>
+  )
+}

--- a/apps/playground/src/app/shadcn/page.tsx
+++ b/apps/playground/src/app/shadcn/page.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import * as React from 'react'
+
+import { OTPInput, OTPInputContext } from 'input-otp'
+import { cn } from '@/lib/utils'
+
+// Isolated reproduction of shadcn/ui's official input-otp component and demo
+// (https://ui.shadcn.com/docs/components/input-otp), the context in which the
+// iOS selection artifact was originally reported (#75, #110). Structure and
+// classNames match the registry source (new-york-v4); shadcn theme tokens are
+// mapped to their zinc defaults since the playground has no shadcn theme, and
+// the lucide MinusIcon is inlined.
+
+function InputOTP({
+  className,
+  containerClassName,
+  ...props
+}: React.ComponentProps<typeof OTPInput> & {
+  containerClassName?: string
+}) {
+  return (
+    <OTPInput
+      data-slot="input-otp"
+      containerClassName={cn(
+        'flex items-center gap-2',
+        containerClassName,
+      )}
+      className={cn('disabled:cursor-not-allowed', className)}
+      {...props}
+    />
+  )
+}
+
+function InputOTPGroup({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="input-otp-group"
+      className={cn('flex items-center', className)}
+      {...props}
+    />
+  )
+}
+
+function InputOTPSlot({
+  index,
+  className,
+  ...props
+}: React.ComponentProps<'div'> & {
+  index: number
+}) {
+  const inputOTPContext = React.useContext(OTPInputContext)
+  const { char, hasFakeCaret, isActive } = inputOTPContext?.slots[index] ?? {}
+
+  return (
+    <div
+      data-slot="input-otp-slot"
+      data-active={isActive}
+      className={cn(
+        'relative flex h-9 w-9 items-center justify-center border-y border-r border-zinc-200 text-sm shadow-sm transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md data-[active=true]:z-10 data-[active=true]:border-zinc-400 data-[active=true]:ring-[3px] data-[active=true]:ring-zinc-400/50',
+        className,
+      )}
+      {...props}
+    >
+      {char}
+      {hasFakeCaret && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="caret-blink h-4 w-px bg-zinc-950" />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function InputOTPSeparator({ ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div data-slot="input-otp-separator" role="separator" {...props}>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      >
+        <path d="M5 12h14" />
+      </svg>
+    </div>
+  )
+}
+
+export default function Page() {
+  const [value, setValue] = React.useState('')
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-white text-zinc-950">
+      <style>{`
+        @keyframes caret-blink { 0%,70%,100% { opacity: 1 } 20%,50% { opacity: 0 } }
+        .caret-blink { animation: caret-blink 1.25s ease-out infinite; }
+      `}</style>
+
+      <div className="space-y-2 text-center">
+        <InputOTP
+          maxLength={6}
+          value={value}
+          onChange={setValue}
+        >
+          <InputOTPGroup>
+            <InputOTPSlot index={0} />
+            <InputOTPSlot index={1} />
+            <InputOTPSlot index={2} />
+          </InputOTPGroup>
+          <InputOTPSeparator />
+          <InputOTPGroup>
+            <InputOTPSlot index={3} />
+            <InputOTPSlot index={4} />
+            <InputOTPSlot index={5} />
+          </InputOTPGroup>
+        </InputOTP>
+        <div className="text-sm text-zinc-500">
+          {value === '' ? (
+            <>Enter your one-time password.</>
+          ) : (
+            <>You entered: {value}</>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/playground/src/tests/base.render.spec.ts
+++ b/apps/playground/src/tests/base.render.spec.ts
@@ -18,6 +18,49 @@ test.describe('Base tests - Render', () => {
     await page.waitForTimeout(100)
     await expect(renderer).not.toHaveAttribute('data-test-render-is-focused')
   })
+  test('should scale down the input on iOS to hide the selection artifact', async ({ page }) => {
+    // The native iOS selection artifact tracks the rendered text size, so
+    // the input is visually scaled down 10x while its computed font-size
+    // stays 16px (the minimum that does not trigger iOS focus zoom).
+    await page.waitForFunction(() => {
+      const styleEl = document.getElementById(
+        'input-otp-style',
+      ) as HTMLStyleElement | null
+      return (styleEl?.sheet?.cssRules.length ?? 0) > 0
+    })
+    const iosRule = await page.evaluate(() => {
+      const styleEl = document.getElementById(
+        'input-otp-style',
+      ) as HTMLStyleElement | null
+      if (!styleEl?.sheet) {
+        return null
+      }
+      return (
+        Array.from(styleEl.sheet.cssRules)
+          .map(rule => rule.cssText)
+          .find(text => text.includes('-webkit-touch-callout')) ?? null
+      )
+    })
+    expect(iosRule).not.toBeNull()
+    expect(iosRule).toContain('font-size: 16px !important')
+    expect(iosRule).toContain('transform: scale(0.1) !important')
+    expect(iosRule).toContain('text-indent: -9999px !important')
+    expect(iosRule).toContain('letter-spacing: -0.6em !important')
+
+    // On engines where the @supports guard matches (real iOS WebKit),
+    // also assert the rule wins over the inline styles.
+    const matchesIOSGuard = await page.evaluate(() =>
+      CSS.supports('-webkit-touch-callout', 'none'),
+    )
+    if (matchesIOSGuard) {
+      const input = page.getByRole('textbox')
+      await expect(input).toHaveCSS('font-size', '16px')
+      await expect(input).toHaveCSS(
+        'transform',
+        'matrix(0.1, 0, 0, 0.1, 0, 0)',
+      )
+    }
+  })
   test('should expose hover flags', async ({ page }) => {
     const renderer = page.getByTestId('input-otp-renderer')
 

--- a/apps/website/src/app/(docs)/docs/edge-cases/page.tsx
+++ b/apps/website/src/app/(docs)/docs/edge-cases/page.tsx
@@ -66,13 +66,10 @@ const SYNC_TIMEOUTS = `export function syncTimeouts(cb: () => unknown) {
 
 const IOS_METRICS = `@supports (-webkit-touch-callout: none) {
   [data-input-otp] {
-    font-size: 16px !important;       /* the focus-zoom threshold */
-    width: 1000% !important;          /* 10x layout box…           */
-    height: 1000% !important;
-    transform: scale(0.1) !important; /* …painted at 1/10th        */
-    transform-origin: 0 0 !important;
     letter-spacing: -.6em !important;
-    text-indent: -9999px !important;  /* park the text offscreen   */
+    font-weight: 100 !important;
+    font-stretch: ultra-condensed;
+    font-optical-sizing: none !important;
     left: -1px !important;
     right: 1px !important;
   }
@@ -81,10 +78,10 @@ const IOS_METRICS = `@supports (-webkit-touch-callout: none) {
 const OPACITY = `opacity: '1', // Mandatory for iOS hold-paste`
 
 const ROOT_HEIGHT = `const updateRootHeight = () => {
-  container.style.setProperty('--root-height', \`\${container.clientHeight}px\`)
+  container.style.setProperty('--root-height', \`\${input.clientHeight}px\`)
 }
 updateRootHeight()
-new ResizeObserver(updateRootHeight).observe(container)
+new ResizeObserver(updateRootHeight).observe(input)
 
 // …consumed by the input's own style:
 fontSize: 'var(--root-height)'`
@@ -429,7 +426,7 @@ export default function EdgeCasesPage() {
             <A href="https://github.com/guilhermerodz/input-otp/issues/32">
               #32
             </A>
-            . Fixed in <C>1.5.0-beta.1</C>.
+            . It remains a cosmetic limitation in 1.5.0.
           </>
         }
         cause={
@@ -441,17 +438,13 @@ export default function EdgeCasesPage() {
         }
         fix={
           <>
-            An iOS-only block parks the text offscreen (<C>text-indent</C>) so
-            nothing paints at rest, and scales the input down 10x — with a
-            compensating 10x layout box, so the tap area still matches the
-            container — which floors the highlight at iOS&apos;s ~2px minimum.
-            Computed <C>font-size</C> stays at 16px, below which focusing would
-            zoom the page. During a pointer gesture the text is revealed at the
-            fingertip via an inline <C>text-indent</C> so the copy/paste menu
-            can anchor, and hidden again on typing, blur or scroll. The{' '}
-            <C>left: -1px</C> / <C>right: 1px</C> pair survives from the old
-            metrics fix: the nudge that repositioned the glyphs also moved the
-            field, so the second declaration restores it.
+            The stable implementation compresses the underlying text with
+            collapsed letter spacing and light, condensed metrics. This keeps
+            the native highlight narrow but cannot remove it completely. The
+            input stays in its normal layout box because moving or scaling it
+            can destabilise focus, selection handles and the native edit menu.
+            The artifact is cosmetic; typing, AutoFill, Select All and Paste
+            continue to work.
           </>
         }
       >
@@ -558,11 +551,10 @@ export default function EdgeCasesPage() {
         }
         fix={
           <>
-            A <C>ResizeObserver</C> publishes the container&apos;s pixel height
-            as <C>--root-height</C>, and the input&apos;s <C>font-size</C> is
-            set from it. It is measured on the container rather than the input
-            because on iOS the input&apos;s layout box is enlarged 10x by the
-            scale-down fix. Native UI then matches the boxes the user can see.
+            A <C>ResizeObserver</C> publishes the input&apos;s pixel height as{' '}
+            <C>--root-height</C>, and the input&apos;s <C>font-size</C> is set
+            from it. Native UI then tracks the height of the field while the
+            rendered slots remain fully controlled by your layout.
           </>
         }
       >
@@ -883,7 +875,8 @@ export default function EdgeCasesPage() {
           The space check walks up to the nearest ancestor that constrains
           horizontal overflow, and the gutter is only reserved when the full
           40px fit. When they don&apos;t, the badge stays over the last slot —
-          the same rendering as <C>pushPasswordManagerStrategy=&quot;none&quot;</C>.
+          the same rendering as{' '}
+          <C>pushPasswordManagerStrategy=&quot;none&quot;</C>.
         </p>
         <p>
           <strong className="font-medium text-foreground">

--- a/apps/website/src/app/(docs)/docs/mobile/page.tsx
+++ b/apps/website/src/app/(docs)/docs/mobile/page.tsx
@@ -17,15 +17,11 @@ const SMS_FORMAT = `Your verification code is 123456
 
 const IOS_CSS = `@supports (-webkit-touch-callout: none) {
   [data-input-otp] {
-    font-size: 16px !important;       /* the iOS focus-zoom threshold */
-    width: 1000% !important;          /* enlarge the layout box 10x…   */
-    height: 1000% !important;
-    transform: scale(0.1) !important; /* …and paint it at 1/10th, so the
-                                         tap area still matches the container */
-    transform-origin: 0 0 !important;
-    letter-spacing: -.6em !important; /* collapse the per-char pitch */
-    text-indent: -9999px !important;  /* park the text offscreen */
-    left: -1px !important;            /* nudge, then compensate */
+    letter-spacing: -.6em !important;
+    font-weight: 100 !important;
+    font-stretch: ultra-condensed;
+    font-optical-sizing: none !important;
+    left: -1px !important;
     right: 1px !important;
   }
 }`
@@ -145,35 +141,23 @@ export default function MobilePage() {
       <P>
         iOS draws the selection highlight and the caret in a layer of its own —
         one that ignores <C>::selection</C>, CSS <C>opacity</C> and ancestor
-        clipping. That is why, up to 1.4.x, a thin caret-tall line could show
-        through the invisible input whenever a range was selected. What that
-        native layer <em>does</em> respect is the rendered text geometry, so
-        since <C>1.5.0-beta.1</C> an iOS-only block rewrites it:
+        clipping. The library compresses the underlying text metrics to reduce
+        what that native layer can paint:
       </P>
       <CodeBlock code={IOS_CSS} lang="css" />
       <P>
-        The text is parked offscreen with <C>text-indent</C>, so at rest there
-        is nothing for the native layer to paint — no artifact, at any fill
-        state or selection size. The <C>scale(0.1)</C> pair shrinks the
-        rendered text (and with it the painted highlight, which iOS floors at
-        roughly 2×2px) while the enlarged layout box keeps the tap area
-        exactly matching the container, and the computed <C>font-size</C> stays
-        at 16px so focusing the field never zooms the page.
+        Collapsed letter spacing and light, condensed text keep the native
+        selection narrow. They cannot hide it completely: a thin caret-tall line
+        may still appear while a range is selected. The input remains in its
+        normal layout box so focus, selection handles and the edit menu use the
+        platform&apos;s proven geometry.
       </P>
-      <P>
-        The copy/paste menu still works because it only needs an on-screen
-        caret rect <em>during a gesture</em>: on <C>pointerdown</C> the library
-        reveals the text at the fingertip&apos;s position (an inline{' '}
-        <C>text-indent</C> beats the stylesheet&apos;s <C>-9999px</C>), and
-        hides it again on typing, blur or scroll — at most a ~2px fleck under
-        the finger while the gesture is active.
-      </P>
-      <Callout type="note" title="Remove your own artifact workarounds">
+      <Callout type="warning" title="Known iOS limitation">
         <p>
-          If you patched the old artifact yourself — <C>font-size: 16px</C>{' '}
-          overrides, custom transforms or <C>text-indent</C> on{' '}
-          <C>[data-input-otp]</C> — remove those: overriding the input&apos;s
-          geometry can now interfere with the fix.
+          The selection artifact is cosmetic. Typing, SMS AutoFill, Select All,
+          Paste and the native edit menu continue to work. Avoid moving, scaling
+          or hiding <C>[data-input-otp]</C>; those workarounds can break the
+          native interactions they are trying to preserve.
         </p>
       </Callout>
       <P>

--- a/apps/website/src/app/(docs)/docs/page.tsx
+++ b/apps/website/src/app/(docs)/docs/page.tsx
@@ -123,9 +123,10 @@ export default function IntroductionPage() {
         <Li>
           iOS paints the selection and caret in a native layer no CSS can hide,
           and refuses to show the long-press paste menu on a zero-opacity input
-          — so a dedicated set of iOS-only rules parks the text offscreen,
-          scales the field down 10x, and a paste handler does the insertion by
-          hand.
+          — so iOS-only typography keeps the native artifact narrow while a
+          paste handler performs the insertion by hand. A thin selection line
+          can still appear; keeping the input in its normal geometry preserves
+          focus, selection handles and the native edit menu.
         </Li>
         <Li>
           Autofill paints its own background colour over a field you asked to be

--- a/packages/input-otp/package.json
+++ b/packages/input-otp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "input-otp",
-  "version": "1.4.2",
+  "version": "1.5.0-beta.1",
   "author": "Guilherme Rodz <g@rodz.dev>",
   "description": "One-time password input component for React.",
   "license": "MIT",

--- a/packages/input-otp/package.json
+++ b/packages/input-otp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "input-otp",
-  "version": "1.4.2",
+  "version": "1.5.0-beta.2",
   "author": "Guilherme Rodz <g@rodz.dev>",
   "description": "One-time password input component for React.",
   "license": "MIT",

--- a/packages/input-otp/package.json
+++ b/packages/input-otp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "input-otp",
-  "version": "1.5.0-beta.2",
+  "version": "1.5.0",
   "author": "Guilherme Rodz <g@rodz.dev>",
   "description": "One-time password input component for React.",
   "license": "MIT",

--- a/packages/input-otp/src/input.tsx
+++ b/packages/input-otp/src/input.tsx
@@ -11,6 +11,13 @@ export const OTPInputContext = React.createContext<RenderProps>(
   {} as RenderProps,
 )
 
+/** Failsafe for the iOS text reveal (see the reveal logic in the effect
+ *  below): only fires when a gesture is interrupted before `pointerup`.
+ *  Generous on purpose — a normal interaction is ended by typing, blur or
+ *  scroll long before this, and being late here is harmless while being
+ *  early can dismiss the native edit menu. */
+const IOS_REVEAL_BACKSTOP_MS = 5000
+
 export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
   (
     {
@@ -193,10 +200,26 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
             styleEl.sheet,
             `[data-input-otp]:-webkit-autofill { ${autofillStyles} }`,
           )
-          // iOS
+          // iOS does not allow styling `::selection` on inputs, so the native
+          // selection/caret artifact stays visible whenever a range is
+          // selected. The overlay ignores CSS opacity and ancestor clipping,
+          // but it does track the rendered text geometry, so:
+          // - `text-indent: -9999px` parks the text (and the artifact)
+          //   offscreen — nothing is ever visible at rest. The reveal logic
+          //   below brings it back only during pointer gestures, because the
+          //   copy/paste menu only appears when it can anchor to an
+          //   on-screen caret/selection rect.
+          // - `letter-spacing: -.6em` collapses the per-char pitch to ~0 so
+          //   a selection renders the same size whether 1 or 6 chars are
+          //   selected (no width growth during the reveal).
+          // - the 10x scale-down compresses the caret-height artifact; iOS
+          //   floors the painted highlight at ~2x2px, so the reveal shows at
+          //   most a constant 2px fleck.
+          // - computed font-size must stay >=16px or focusing the input
+          //   zooms the page (WebKit checks computed, not rendered, size).
           safeInsertRule(
             styleEl.sheet,
-            `@supports (-webkit-touch-callout: none) { [data-input-otp] { letter-spacing: -.6em !important; font-weight: 100 !important; font-stretch: ultra-condensed; font-optical-sizing: none !important; left: -1px !important; right: 1px !important; } }`,
+            `@supports (-webkit-touch-callout: none) { [data-input-otp] { font-size: 16px !important; width: 1000% !important; height: 1000% !important; transform: scale(0.1) !important; transform-origin: 0 0 !important; letter-spacing: -.6em !important; text-indent: -9999px !important; left: -1px !important; right: 1px !important; } }`,
           )
           // PWM badges
           safeInsertRule(
@@ -205,12 +228,14 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
           )
         }
       }
-      // Track root height
+      // Track root height. Measured on the container, not the input,
+      // because on iOS the input's layout box is enlarged 10x (see the
+      // scale-down rule above) while the container keeps the true size.
       const updateRootHeight = () => {
         if (container) {
           container.style.setProperty(
             '--root-height',
-            `${input.clientHeight}px`,
+            `${container.clientHeight}px`,
           )
         }
       }
@@ -221,7 +246,98 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
         typeof ResizeObserver === 'undefined'
           ? null
           : new ResizeObserver(updateRootHeight)
-      resizeObserver?.observe(input)
+      resizeObserver?.observe(container)
+
+      // iOS: the text is parked offscreen (see the iOS rule above) so the
+      // native selection artifact is never visible at rest. The copy/paste
+      // menu, however, only appears when the tap/long-press lands near an
+      // on-screen caret/selection rect — so reveal the text while the user
+      // is interacting and hide it again once the interaction ends. Inline
+      // `text-indent` wins over the stylesheet's `-9999px`; removing it
+      // falls back to hidden.
+      //
+      // Hiding is event-driven rather than timed: the edit menu tracks its
+      // anchor rect while it presents, so a timer racing that animation can
+      // dismiss the menu (measured: hiding 400ms after pointerup killed it,
+      // 1500ms did not — but that margin is device- and OS-dependent, so we
+      // don't rely on it). Instead we hide on the events that actually mean
+      // "the interaction is over" — typing, blur, scroll — and keep a long
+      // backstop timer purely so an interrupted gesture (a pointerup that
+      // never arrives) can't leave the text revealed indefinitely.
+      let cleanupIOSReveal: (() => void) | null = null
+      if (initialLoadRef.current.isIOS) {
+        let isPointerDown = false
+        let pointerX = 0
+        let backstopTimer: ReturnType<typeof setTimeout> | undefined
+        // The text is revealed at the pointer's x position, so the ~2px
+        // artifact renders under the fingertip (occluded by it) and the
+        // edit menu anchors at the touch point. offsetX is in the input's
+        // pre-transform coordinate space, matching text-indent.
+        const hideText = () => {
+          clearTimeout(backstopTimer)
+          input.style.removeProperty('text-indent')
+        }
+        // Armed whenever the text is revealed — not only on pointerup, since
+        // iOS's text-interaction gesture recognizer can swallow pointerup
+        // entirely (observed on iOS 18 when a tap opens the edit menu),
+        // which would otherwise leave the text revealed indefinitely. For
+        // the same reason the hide is unconditional: any "is the finger
+        // still down?" check can be permanently stale. Firing mid-gesture is
+        // safe in practice — the edit menu only dismisses if its anchor
+        // moves while it is still presenting, which is far shorter than this.
+        const armBackstop = () => {
+          clearTimeout(backstopTimer)
+          backstopTimer = setTimeout(hideText, IOS_REVEAL_BACKSTOP_MS)
+        }
+        const revealText = () => {
+          input.style.setProperty(
+            'text-indent',
+            `${Math.max(0, pointerX)}px`,
+            'important',
+          )
+          armBackstop()
+        }
+        const onPointerDown = (e: PointerEvent) => {
+          isPointerDown = true
+          pointerX = e.offsetX
+          if (document.activeElement === input) {
+            revealText()
+          }
+        }
+        const onPointerUp = () => {
+          isPointerDown = false
+          armBackstop()
+        }
+        // Long-press on an unfocused input: focus arrives while the pointer
+        // is still down and the menu will anchor on release.
+        const onFocus = () => {
+          if (isPointerDown) {
+            revealText()
+          }
+        }
+        input.addEventListener('pointerdown', onPointerDown)
+        input.addEventListener('pointerup', onPointerUp)
+        input.addEventListener('pointercancel', onPointerUp)
+        input.addEventListener('focus', onFocus)
+        input.addEventListener('input', hideText)
+        input.addEventListener('blur', hideText)
+        // Scrolling dismisses the edit menu natively, so it's a reliable
+        // end-of-interaction signal.
+        window.addEventListener('scroll', hideText, {
+          capture: true,
+          passive: true,
+        })
+        cleanupIOSReveal = () => {
+          clearTimeout(backstopTimer)
+          input.removeEventListener('pointerdown', onPointerDown)
+          input.removeEventListener('pointerup', onPointerUp)
+          input.removeEventListener('pointercancel', onPointerUp)
+          input.removeEventListener('focus', onFocus)
+          input.removeEventListener('input', hideText)
+          input.removeEventListener('blur', hideText)
+          window.removeEventListener('scroll', hideText, { capture: true })
+        }
+      }
 
       return () => {
         document.removeEventListener(
@@ -230,6 +346,7 @@ export const OTPInput = React.forwardRef<HTMLInputElement, OTPInputProps>(
           { capture: true },
         )
         resizeObserver?.disconnect()
+        cleanupIOSReveal?.()
       }
       // The style tag is created once per document, so only the first
       // render's nonce can ever be used — a mount-only effect is intended.


### PR DESCRIPTION
## Status

**Draft / `1.6.0-beta.0` experiment. Not part of the 1.5 stable train.**

## What

Reintroduces the effective code from #115 as a new 1.6 beta experiment after the workaround was withdrawn from 1.5 stable in #139.

- parks the iOS input text offscreen at rest
- reveals it at the pointer position while the native edit menu needs an anchor
- uses collapsed/scaled text with a compensating layout box
- measures `--root-height` from the container
- restores `/ios-probe` and `/shadcn` manual test pages
- documents the behavior as beta-only and keeps stable 1.5 behavior explicit
- sets the package version to `1.6.0-beta.0`

## Dependency

This draft is stacked on the 1.5 release train:

1. #141 publishes the safe `1.5.0-beta.2`.
2. #142 promotes that code to `1.5.0` after soak.
3. This PR should be rebased/refreshed after those land so its final diff contains only the 1.6 experiment.

## Required before any promotion

- real-device SMS AutoFill
- Select All → Paste through the native menu
- type-over-when-full
- RTL
- iPadOS Scribble and pointer
- multi-version iOS soak
- explicit review of the enlarged input geometry and event listeners

Equivalent in behavior to #115, but intentionally moved to the next minor beta line.