### PR TITLE
chore(release): prepare 1.5.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
+## [1.5.0-beta.2]
+
+Safe release candidate for 1.5.0. This release withdraws the experimental iOS native-selection workaround from 1.5.0-beta.1 after compatibility review. The edit menu, paste, typing, selection and focus behavior return to the proven 1.4.x implementation; the thin native selection artifact remains a known iOS limitation.
+
+- revert(input): withdraw the experimental iOS native-selection workaround from 1.5.0-beta.1
+- docs: align the mobile and edge-case documentation with the stable candidate
+- test: verify focus, typing, editing, deletion, paste, Select All → Paste and the native edit menu on iOS 18.0 and 26.5 simulators
+
+## [1.5.0-beta.1]
+
+Deprecated experimental release. It introduced an iOS native-selection workaround that moved and scaled the underlying input. The workaround was withdrawn in 1.5.0-beta.2 and is not planned for 1.5.0 stable. Existing installs remain reproducible, but new beta users should use 1.5.0-beta.2 or later.
+
 ## [1.5.0-beta.0]
+
+Prepared but not published. Its safe changes are included in 1.5.0-beta.2.
 
 - fix(input): reserve the password manager badge gutter only where it fits
   - Once a badge was detected, the input grew 40px past the container to push the badge off the last slot — and the only guard was the distance to the viewport's right edge. Inside a constrained scroll container (a card, a modal) that overhang registered as scrollable overflow: a horizontal scrollbar appeared and shifted the whole layout. The space check now measures the nearest ancestor that constrains horizontal overflow (scroll containers, `overflow: hidden`/`clip` ancestors, the container itself, and the real viewport width) and skips the push when the gutter doesn't fit; the badge then stays over the last slot, exactly as with `pushPasswordManagerStrategy="none"`. Nothing is ever clipped, so extensions keep rendering their badges.
@@ -22,8 +36,6 @@
   - Some environments reject individual cosmetic selectors (`:autofill` in older Android WebViews, for instance). Nothing breaks when that happens, but the `console.error` was captured by Sentry and similar tools as if the application had failed. Same message, warning level.
 - chore(types): narrow `onComplete` to `(value: string) => unknown`
   - The declaration was a variadic `(...args: any[]) => unknown`, but the only call site has always passed a single string. Handlers declaring extra parameters (which could never receive values) now fail to compile; every zero-arg or `(code: string)` handler keeps compiling unchanged.
-
-Beta while the iOS fix soaks on real devices. Verified so far on iOS 26.5 (Simulator + manual pass): no artifact at rest, no focus zoom, tap-to-focus, edit menu via double-tap and long-press, paste into full and empty inputs, typing. Still being validated across iOS versions before stable: Select All → Paste from the edit menu, SMS AutoFill from Messages, type-over-when-full, RTL, and iPadOS (Scribble, pointer).
 
 ## [1.4.2]
 
@@ -99,7 +111,7 @@ I'm sorry to skip `1.3.0` due to an issue I've had while publishing the NPM pack
 - fix(input): reinforce wrapper to pointerEvents none
 - feat(input): add experimental push pwm badge
 - chore(input): rename prop to pushPasswordManagerStrategy
-- chore(input): move focus logic to _focusListener
+- chore(input): move focus logic to \_focusListener
 - fix(input): reinforce no box shadows
 - perf(input): rewrite core in a single event listener
 - fix(input): safe insert css rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,16 @@
 
 Safe release candidate for 1.5.0. This release withdraws the experimental iOS native-selection workaround from 1.5.0-beta.1 after compatibility review. The edit menu, paste, typing, selection and focus behavior return to the proven 1.4.x implementation; the thin native selection artifact remains a known iOS limitation.
 
+It also withdraws the `onComplete` type narrowing from 1.5.0-beta.1. Although type-level only, it can fail compilation of existing handlers typed with extra or non-string parameters (a common example is passing react-hook-form's `handleSubmit(onSubmit)` directly), which makes it a breaking change under semver. It will return in 2.0.0 with a documented migration path.
+
 - revert(input): withdraw the experimental iOS native-selection workaround from 1.5.0-beta.1
+- revert(types): withdraw the `onComplete` narrowing from 1.5.0-beta.1, deferring it to 2.0.0
 - docs: align the mobile and edge-case documentation with the stable candidate
 - test: verify focus, typing, editing, deletion, paste, Select All → Paste and the native edit menu on iOS 18.0 and 26.5 simulators
 
 ## [1.5.0-beta.1]
 
-Deprecated experimental release. It introduced an iOS native-selection workaround that moved and scaled the underlying input. The workaround was withdrawn in 1.5.0-beta.2 and is not planned for 1.5.0 stable. Existing installs remain reproducible, but new beta users should use 1.5.0-beta.2 or later.
+Deprecated experimental release. It introduced an iOS native-selection workaround that moved and scaled the underlying input, and narrowed the `onComplete` type in a way that can break compilation of existing apps. Both were withdrawn in 1.5.0-beta.2 and are not planned for 1.5.0 stable. Existing installs remain reproducible, but new beta users should use 1.5.0-beta.2 or later.
 
 ## [1.5.0-beta.0]
 
@@ -34,8 +37,8 @@ Prepared but not published. Its safe changes are included in 1.5.0-beta.2.
   - Chrome's translator rewrote the slots' text nodes (wrapping them in `<font>` elements), crashing React on the next re-render — easiest to hit with alphanumeric codes under an active page translation. The container now carries `translate="no"`; a one-time code is never meaningful to translate.
 - fix(input): log CSS rule insertion failures as warnings, not errors
   - Some environments reject individual cosmetic selectors (`:autofill` in older Android WebViews, for instance). Nothing breaks when that happens, but the `console.error` was captured by Sentry and similar tools as if the application had failed. Same message, warning level.
-- chore(types): narrow `onComplete` to `(value: string) => unknown`
-  - The declaration was a variadic `(...args: any[]) => unknown`, but the only call site has always passed a single string. Handlers declaring extra parameters (which could never receive values) now fail to compile; every zero-arg or `(code: string)` handler keeps compiling unchanged.
+- ~~chore(types): narrow `onComplete` to `(value: string) => unknown`~~
+  - Withdrawn in 1.5.0-beta.2: the narrowing fails compilation of handlers typed with extra or non-string parameters, so it is a breaking change. Deferred to 2.0.0.
 
 ## [1.4.2]
 

--- a/apps/website/src/app/(docs)/docs/edge-cases/page.tsx
+++ b/apps/website/src/app/(docs)/docs/edge-cases/page.tsx
@@ -66,13 +66,10 @@ const SYNC_TIMEOUTS = `export function syncTimeouts(cb: () => unknown) {
 
 const IOS_METRICS = `@supports (-webkit-touch-callout: none) {
   [data-input-otp] {
-    font-size: 16px !important;       /* the focus-zoom threshold */
-    width: 1000% !important;          /* 10x layout box…           */
-    height: 1000% !important;
-    transform: scale(0.1) !important; /* …painted at 1/10th        */
-    transform-origin: 0 0 !important;
     letter-spacing: -.6em !important;
-    text-indent: -9999px !important;  /* park the text offscreen   */
+    font-weight: 100 !important;
+    font-stretch: ultra-condensed;
+    font-optical-sizing: none !important;
     left: -1px !important;
     right: 1px !important;
   }
@@ -81,10 +78,10 @@ const IOS_METRICS = `@supports (-webkit-touch-callout: none) {
 const OPACITY = `opacity: '1', // Mandatory for iOS hold-paste`
 
 const ROOT_HEIGHT = `const updateRootHeight = () => {
-  container.style.setProperty('--root-height', \`\${container.clientHeight}px\`)
+  container.style.setProperty('--root-height', \`\${input.clientHeight}px\`)
 }
 updateRootHeight()
-new ResizeObserver(updateRootHeight).observe(container)
+new ResizeObserver(updateRootHeight).observe(input)
 
 // …consumed by the input's own style:
 fontSize: 'var(--root-height)'`
@@ -429,7 +426,7 @@ export default function EdgeCasesPage() {
             <A href="https://github.com/guilhermerodz/input-otp/issues/32">
               #32
             </A>
-            . Fixed in <C>1.5.0-beta.1</C>.
+            . It remains a cosmetic limitation in 1.5.0.
           </>
         }
         cause={
@@ -441,17 +438,13 @@ export default function EdgeCasesPage() {
         }
         fix={
           <>
-            An iOS-only block parks the text offscreen (<C>text-indent</C>) so
-            nothing paints at rest, and scales the input down 10x — with a
-            compensating 10x layout box, so the tap area still matches the
-            container — which floors the highlight at iOS&apos;s ~2px minimum.
-            Computed <C>font-size</C> stays at 16px, below which focusing would
-            zoom the page. During a pointer gesture the text is revealed at the
-            fingertip via an inline <C>text-indent</C> so the copy/paste menu
-            can anchor, and hidden again on typing, blur or scroll. The{' '}
-            <C>left: -1px</C> / <C>right: 1px</C> pair survives from the old
-            metrics fix: the nudge that repositioned the glyphs also moved the
-            field, so the second declaration restores it.
+            The stable implementation compresses the underlying text with
+            collapsed letter spacing and light, condensed metrics. This keeps
+            the native highlight narrow but cannot remove it completely. The
+            input stays in its normal layout box because moving or scaling it
+            can destabilise focus, selection handles and the native edit menu.
+            The artifact is cosmetic; typing, AutoFill, Select All and Paste
+            continue to work.
           </>
         }
       >
@@ -558,11 +551,10 @@ export default function EdgeCasesPage() {
         }
         fix={
           <>
-            A <C>ResizeObserver</C> publishes the container&apos;s pixel height
-            as <C>--root-height</C>, and the input&apos;s <C>font-size</C> is
-            set from it. It is measured on the container rather than the input
-            because on iOS the input&apos;s layout box is enlarged 10x by the
-            scale-down fix. Native UI then matches the boxes the user can see.
+            A <C>ResizeObserver</C> publishes the input&apos;s pixel height as{' '}
+            <C>--root-height</C>, and the input&apos;s <C>font-size</C> is set
+            from it. Native UI then tracks the height of the field while the
+            rendered slots remain fully controlled by your layout.
           </>
         }
       >
@@ -883,7 +875,8 @@ export default function EdgeCasesPage() {
           The space check walks up to the nearest ancestor that constrains
           horizontal overflow, and the gutter is only reserved when the full
           40px fit. When they don&apos;t, the badge stays over the last slot —
-          the same rendering as <C>pushPasswordManagerStrategy=&quot;none&quot;</C>.
+          the same rendering as{' '}
+          <C>pushPasswordManagerStrategy=&quot;none&quot;</C>.
         </p>
         <p>
           <strong className="font-medium text-foreground">

--- a/apps/website/src/app/(docs)/docs/mobile/page.tsx
+++ b/apps/website/src/app/(docs)/docs/mobile/page.tsx
@@ -17,15 +17,11 @@ const SMS_FORMAT = `Your verification code is 123456
 
 const IOS_CSS = `@supports (-webkit-touch-callout: none) {
   [data-input-otp] {
-    font-size: 16px !important;       /* the iOS focus-zoom threshold */
-    width: 1000% !important;          /* enlarge the layout box 10x…   */
-    height: 1000% !important;
-    transform: scale(0.1) !important; /* …and paint it at 1/10th, so the
-                                         tap area still matches the container */
-    transform-origin: 0 0 !important;
-    letter-spacing: -.6em !important; /* collapse the per-char pitch */
-    text-indent: -9999px !important;  /* park the text offscreen */
-    left: -1px !important;            /* nudge, then compensate */
+    letter-spacing: -.6em !important;
+    font-weight: 100 !important;
+    font-stretch: ultra-condensed;
+    font-optical-sizing: none !important;
+    left: -1px !important;
     right: 1px !important;
   }
 }`
@@ -145,35 +141,23 @@ export default function MobilePage() {
       <P>
         iOS draws the selection highlight and the caret in a layer of its own —
         one that ignores <C>::selection</C>, CSS <C>opacity</C> and ancestor
-        clipping. That is why, up to 1.4.x, a thin caret-tall line could show
-        through the invisible input whenever a range was selected. What that
-        native layer <em>does</em> respect is the rendered text geometry, so
-        since <C>1.5.0-beta.1</C> an iOS-only block rewrites it:
+        clipping. The library compresses the underlying text metrics to reduce
+        what that native layer can paint:
       </P>
       <CodeBlock code={IOS_CSS} lang="css" />
       <P>
-        The text is parked offscreen with <C>text-indent</C>, so at rest there
-        is nothing for the native layer to paint — no artifact, at any fill
-        state or selection size. The <C>scale(0.1)</C> pair shrinks the
-        rendered text (and with it the painted highlight, which iOS floors at
-        roughly 2×2px) while the enlarged layout box keeps the tap area
-        exactly matching the container, and the computed <C>font-size</C> stays
-        at 16px so focusing the field never zooms the page.
+        Collapsed letter spacing and light, condensed text keep the native
+        selection narrow. They cannot hide it completely: a thin caret-tall line
+        may still appear while a range is selected. The input remains in its
+        normal layout box so focus, selection handles and the edit menu use the
+        platform&apos;s proven geometry.
       </P>
-      <P>
-        The copy/paste menu still works because it only needs an on-screen
-        caret rect <em>during a gesture</em>: on <C>pointerdown</C> the library
-        reveals the text at the fingertip&apos;s position (an inline{' '}
-        <C>text-indent</C> beats the stylesheet&apos;s <C>-9999px</C>), and
-        hides it again on typing, blur or scroll — at most a ~2px fleck under
-        the finger while the gesture is active.
-      </P>
-      <Callout type="note" title="Remove your own artifact workarounds">
+      <Callout type="warning" title="Known iOS limitation">
         <p>
-          If you patched the old artifact yourself — <C>font-size: 16px</C>{' '}
-          overrides, custom transforms or <C>text-indent</C> on{' '}
-          <C>[data-input-otp]</C> — remove those: overriding the input&apos;s
-          geometry can now interfere with the fix.
+          The selection artifact is cosmetic. Typing, SMS AutoFill, Select All,
+          Paste and the native edit menu continue to work. Avoid moving, scaling
+          or hiding <C>[data-input-otp]</C>; those workarounds can break the
+          native interactions they are trying to preserve.
         </p>
       </Callout>
       <P>

--- a/apps/website/src/app/(docs)/docs/page.tsx
+++ b/apps/website/src/app/(docs)/docs/page.tsx
@@ -123,9 +123,10 @@ export default function IntroductionPage() {
         <Li>
           iOS paints the selection and caret in a native layer no CSS can hide,
           and refuses to show the long-press paste menu on a zero-opacity input
-          — so a dedicated set of iOS-only rules parks the text offscreen,
-          scales the field down 10x, and a paste handler does the insertion by
-          hand.
+          — so iOS-only typography keeps the native artifact narrow while a
+          paste handler performs the insertion by hand. A thin selection line
+          can still appear; keeping the input in its normal geometry preserves
+          focus, selection handles and the native edit menu.
         </Li>
         <Li>
           Autofill paints its own background colour over a field you asked to be

--- a/packages/input-otp/package.json
+++ b/packages/input-otp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "input-otp",
-  "version": "1.4.2",
+  "version": "1.5.0-beta.2",
   "author": "Guilherme Rodz <g@rodz.dev>",
   "description": "One-time password input component for React.",
   "license": "MIT",

--- a/packages/input-otp/src/types.ts
+++ b/packages/input-otp/src/types.ts
@@ -20,7 +20,10 @@ type OTPInputBaseProps = OverrideProps<
 
     textAlign?: 'left' | 'center' | 'right'
 
-    onComplete?: (value: string) => unknown
+    // Deliberately variadic until 2.0.0: narrowing to `(value: string)`
+    // breaks compilation of handlers typed with extra or non-string params
+    // (e.g. react-hook-form's `handleSubmit(onSubmit)` passed directly).
+    onComplete?: (...args: any[]) => unknown
     pushPasswordManagerStrategy?: 'increase-width' | 'none'
     pasteTransformer?: (pasted: string) => string
 


### PR DESCRIPTION
## What

Prepares the safe `1.5.0-beta.2` release candidate after #139 withdrew the high-risk iOS selection workaround.

- sets `input-otp` to `1.5.0-beta.2`
- records `1.5.0-beta.1` as a deprecated experimental release
- preserves the unpublished `1.5.0-beta.0` history
- documents the thin iOS native-selection line as a known cosmetic limitation
- removes claims that stable moves, scales or reveals the input during gestures
- aligns the geometry examples with the code that is actually shipping
- **withdraws the `onComplete` type narrowing from beta.1** (`(...args: any[])` → `(value: string)`): type-level only, but it fails compilation of handlers typed with extra or non-string parameters — e.g. react-hook-form's `handleSubmit(onSubmit)` passed directly — which breaks linters and CIs on a `^1.x` update. Under semver it is a major; it returns in 2.0.0 as a documented breaking change.

## Verification

- package build: pass
- website TypeScript check: pass
- Prettier: pass
- library `tsc --noEmit` + ESLint after the type revert: pass
- iOS 18.0 and 26.5 Simulator matrix completed on the reverted implementation: focus, typing, full-value replacement, editing, deletion, paste, Select All → Paste, blur/refocus and native edit-menu paste

## Publish sequence after merge

1. Tag the merged commit as `v1.5.0-beta.2` and push the tag so the release workflow publishes it under `beta`.
2. Confirm `npm view input-otp dist-tags` points `beta` to `1.5.0-beta.2`.
3. Only after beta.2 is live, run:

```sh
npm deprecate input-otp@1.5.0-beta.1 "This beta contains an experimental iOS selection workaround and an onComplete type narrowing that were withdrawn before stable due to compatibility risk. Upgrade to 1.5.0-beta.2 or later."
```

Do not unpublish beta.1; pinned lockfiles must remain reproducible.

## Stable gate

Soak beta.2 before promoting the same functional code to `1.5.0`.
