### PR TITLE
feat(website): versioned docs with a header version selector

### DIFF
--- a/apps/website/src/app/(docs)/_components/docs-header.tsx
+++ b/apps/website/src/app/(docs)/_components/docs-header.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { siteConfig } from '@/config/site'
 import { Icons } from '@/components/icons'
 import { DocsMobileNav } from './docs-sidebar'
+import { VersionSelector } from './version-selector'
 
 function Wordmark() {
   return (
@@ -32,6 +33,7 @@ export function DocsHeader() {
           >
             Docs
           </Link>
+          <VersionSelector />
         </div>
 
         <div className="ml-auto flex items-center gap-3">

--- a/apps/website/src/app/(docs)/_components/docs-sidebar.tsx
+++ b/apps/website/src/app/(docs)/_components/docs-sidebar.tsx
@@ -6,14 +6,16 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 
 import { cn } from '@/lib/utils'
-import { docsNav } from '../_lib/nav'
+import { docsNavForVersion } from '../_lib/nav'
+import { versionForPathname } from '../_lib/versions'
 
 export function DocsSidebarNav({ onNavigate }: { onNavigate?: () => void }) {
   const pathname = usePathname()
+  const nav = docsNavForVersion(versionForPathname(pathname))
 
   return (
     <nav aria-label="Docs" className="text-sm">
-      {docsNav.map(section => (
+      {nav.map(section => (
         <div key={section.title} className="pb-6">
           <p className="mb-2 px-3 text-[0.6875rem] font-semibold uppercase tracking-[0.1em] text-muted-foreground/70">
             {section.title}

--- a/apps/website/src/app/(docs)/_components/props-table.tsx
+++ b/apps/website/src/app/(docs)/_components/props-table.tsx
@@ -5,6 +5,8 @@ export interface PropRow {
   type: string
   default?: string
   required?: boolean
+  /** The release that introduced the prop, when newer than the line's first release. */
+  since?: string
   description: React.ReactNode
 }
 
@@ -30,6 +32,11 @@ export function PropsTable({ rows }: { rows: PropRow[] }) {
                 {row.required && (
                   <span className="rounded border border-amber-500/30 bg-amber-500/10 px-1 py-px text-[0.625rem] font-medium uppercase tracking-wide text-amber-400/90">
                     required
+                  </span>
+                )}
+                {row.since && (
+                  <span className="rounded border border-border/70 bg-foreground/[0.04] px-1 py-px text-[0.625rem] font-medium tracking-wide text-muted-foreground">
+                    since {row.since}
                   </span>
                 )}
               </div>

--- a/apps/website/src/app/(docs)/_components/version-selector.tsx
+++ b/apps/website/src/app/(docs)/_components/version-selector.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import * as React from 'react'
+import { usePathname, useRouter } from 'next/navigation'
+
+import { docsVersions, versionForPathname } from '../_lib/versions'
+import { hrefInVersion } from '../_lib/nav'
+
+/**
+ * The docs version switcher. A native <select> under a styled chip: keyboard
+ * support, screen-reader semantics and mobile pickers come free, and the
+ * visible part stays a small bordered label that matches the header.
+ *
+ * Switching navigates to the same page in the target version, falling back
+ * to that version's root when the page has no counterpart there.
+ */
+export function VersionSelector() {
+  const pathname = usePathname()
+  const router = useRouter()
+  const current = versionForPathname(pathname)
+
+  if (docsVersions.length < 2) {
+    return (
+      <span className="inline-flex h-6 items-center rounded-md border border-border/70 px-2 font-mono text-[0.6875rem] font-medium text-muted-foreground">
+        {current.label}
+      </span>
+    )
+  }
+
+  return (
+    <label className="relative inline-flex h-6 cursor-pointer items-center gap-1 rounded-md border border-border/70 pl-2 pr-1.5 font-mono text-[0.6875rem] font-medium text-muted-foreground transition-colors duration-150 hover:border-border hover:text-foreground">
+      <span aria-hidden>{current.label}</span>
+      <svg
+        aria-hidden
+        viewBox="0 0 8 8"
+        className="h-2 w-2"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+      >
+        <path d="M1.5 3l2.5 2.5L6.5 3" />
+      </svg>
+      <select
+        aria-label="Documentation version"
+        value={current.id}
+        onChange={event => {
+          const target = docsVersions.find(
+            version => version.id === event.target.value,
+          )
+          if (target && target.id !== current.id) {
+            router.push(hrefInVersion(pathname, target))
+          }
+        }}
+        className="absolute inset-0 cursor-pointer appearance-none opacity-0"
+      >
+        {docsVersions.map(version => (
+          <option key={version.id} value={version.id}>
+            {version.label}
+            {version.status === 'latest' ? ' (latest)' : ''}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}

--- a/apps/website/src/app/(docs)/_lib/nav.ts
+++ b/apps/website/src/app/(docs)/_lib/nav.ts
@@ -4,6 +4,12 @@
  * sidebar and the pager pick it up automatically.
  */
 
+import {
+  latestDocsVersion,
+  versionForPathname,
+  type DocsVersion,
+} from './versions'
+
 export interface DocsPageMeta {
   title: string
   href: string
@@ -117,22 +123,57 @@ export const docsNav: DocsSection[] = [
   },
 ]
 
+/**
+ * Every version's nav, keyed by version id. The latest line lives in
+ * `docsNav` above; a frozen major gets its own literal snapshot file (so
+ * future edits to the latest nav can't leak into it) registered here.
+ */
+const navByVersion: Record<string, DocsSection[]> = {
+  [latestDocsVersion.id]: docsNav,
+}
+
+export function docsNavForVersion(version: DocsVersion): DocsSection[] {
+  return navByVersion[version.id] ?? docsNav
+}
+
+export function docsPagesForVersion(version: DocsVersion): DocsPageMeta[] {
+  return docsNavForVersion(version).flatMap(section => section.pages)
+}
+
 /** Flat, ordered list of every docs page — used for prev/next. */
 export const docsPages: DocsPageMeta[] = docsNav.flatMap(
   section => section.pages,
 )
 
 export function getDocsPage(href: string): DocsPageMeta | undefined {
-  return docsPages.find(page => page.href === href)
+  return docsPagesForVersion(versionForPathname(href)).find(
+    page => page.href === href,
+  )
 }
 
+/** Prev/next never cross a version boundary: the pager is scoped to the version the page belongs to. */
 export function getDocsPager(href: string) {
-  const index = docsPages.findIndex(page => page.href === href)
+  const pages = docsPagesForVersion(versionForPathname(href))
+  const index = pages.findIndex(page => page.href === href)
   if (index === -1) {
     return { prev: undefined, next: undefined }
   }
   return {
-    prev: index > 0 ? docsPages[index - 1] : undefined,
-    next: index < docsPages.length - 1 ? docsPages[index + 1] : undefined,
+    prev: index > 0 ? pages[index - 1] : undefined,
+    next: index < pages.length - 1 ? pages[index + 1] : undefined,
   }
+}
+
+/**
+ * The equivalent of `pathname` in `target` — or the target's root when the
+ * page has no counterpart there (a page added after the snapshot, say).
+ */
+export function hrefInVersion(pathname: string, target: DocsVersion): string {
+  const current = versionForPathname(pathname)
+  const suffix =
+    pathname === current.base ? '' : pathname.slice(current.base.length)
+  const candidate = target.base + suffix
+  return docsPagesForVersion(target).some(page => page.href === candidate)
+    ? candidate
+    : target.base
 }

--- a/apps/website/src/app/(docs)/_lib/versions.ts
+++ b/apps/website/src/app/(docs)/_lib/versions.ts
@@ -1,0 +1,38 @@
+/**
+ * The docs version registry. `/docs/*` always documents the latest stable
+ * line; when a new major ships, the previous line is frozen as a full
+ * snapshot under `/docs/v<major>/*` and registered here as `frozen`.
+ *
+ * Minor releases never fork the docs — additions are marked inline with
+ * `since` badges instead (see PropsTable), so readers on an older minor can
+ * tell exactly which parts don't apply to them yet.
+ */
+
+export interface DocsVersion {
+  /** Stable registry key — the major line ('v1', 'v2'). */
+  id: string
+  /** What the version selector displays. */
+  label: string
+  /** This version's URL root: '/docs' for latest, '/docs/v1' for a snapshot. */
+  base: string
+  status: 'latest' | 'frozen'
+}
+
+export const docsVersions: DocsVersion[] = [
+  { id: 'v1', label: 'v1.x', base: '/docs', status: 'latest' },
+]
+
+export const latestDocsVersion = docsVersions.find(
+  version => version.status === 'latest',
+)!
+
+/** Which version a /docs pathname belongs to. Frozen bases win; everything else is latest. */
+export function versionForPathname(pathname: string): DocsVersion {
+  for (const version of docsVersions) {
+    if (version.status !== 'frozen') continue
+    if (pathname === version.base || pathname.startsWith(version.base + '/')) {
+      return version
+    }
+  }
+  return latestDocsVersion
+}

--- a/apps/website/src/app/(docs)/docs/api/page.tsx
+++ b/apps/website/src/app/(docs)/docs/api/page.tsx
@@ -265,6 +265,7 @@ export default function ApiPage() {
           {
             name: 'nonce',
             type: 'string',
+            since: '1.5.0',
             description: (
               <>
                 Applied to the <code>&lt;style&gt;</code> tag the library
@@ -282,8 +283,8 @@ export default function ApiPage() {
           Unless you pass your own, the input gets{' '}
           <C>autoComplete=&quot;one-time-code&quot;</C>, which is what lets iOS
           and Android offer the code straight from the SMS. Overriding it turns
-          SMS autofill off. <C>spellCheck</C> likewise defaults to{' '}
-          <C>false</C> — browsers would underline a full code as a typo — and
+          SMS autofill off. <C>spellCheck</C> likewise defaults to <C>false</C>{' '}
+          since 1.5.0 — browsers would underline a full code as a typo — and
           passing your own value overrides it.
         </p>
       </Callout>

--- a/apps/website/src/app/(docs)/docs/password-managers/page.tsx
+++ b/apps/website/src/app/(docs)/docs/password-managers/page.tsx
@@ -209,10 +209,14 @@ export default function PasswordManagersPage() {
       </P>
       <CodeBlock code={SPACE_CHECK} lang="ts" />
       <P>
-        Both conditions have to hold: a badge was detected <em>and</em> the
-        full 40px gutter fits. Otherwise the width stays at <C>100%</C> and the
-        badge simply stays over the last slot — the same rendering as{' '}
-        <C>pushPasswordManagerStrategy=&quot;none&quot;</C>.
+        Both conditions have to hold: a badge was detected <em>and</em> the full
+        40px gutter fits. Otherwise the width stays at <C>100%</C> and the badge
+        simply stays over the last slot — the same rendering as{' '}
+        <C>pushPasswordManagerStrategy=&quot;none&quot;</C>. The
+        overflow-constraining-ancestor measurement shipped in 1.5.0; before
+        that, only the distance to the viewport&apos;s right edge was checked,
+        so inside a card or modal the overhang could register as scrollable
+        overflow and shift the layout.
       </P>
 
       <H2>Opting out</H2>


### PR DESCRIPTION
## What

Gives `/docs` an explicit versioning model, ahead of the 1.5.0 → 2.0.0 release train:

- **`/docs/*` always documents the latest stable line.** When a new major ships, the previous line is frozen as a full snapshot under `/docs/v<major>/*` and registered in `_lib/versions.ts` (the 2.0 release PR #145 will carry the `/docs/v1` snapshot).
- **Version selector in the docs header** — a native `<select>` under a styled chip (keyboard + screen-reader semantics for free). While only one version exists it renders as a static `v1.x` chip; with two or more it becomes a dropdown that navigates to the same page in the target version, falling back to that version's root.
- **`nav.ts` is version-aware**: sidebar, pager and page metadata resolve through the version a pathname belongs to, and prev/next never cross a version boundary.
- **Minor releases never fork the docs.** Instead, `PropsTable` gains a `since` badge and prose notes mark behavior by release: `nonce` is badged *since 1.5.0*, the `spellCheck=false` default is dated, and the password-manager gutter fit-check notes what 1.4.2 did before. A reader on any 1.x minor can tell exactly which parts apply to them.

## Why now

`/docs` currently describes the 1.5.0 line while npm `latest` is still 1.4.2 — the since-badges close that gap immediately, and the selector mechanism must be on master before #145 can freeze the 1.x snapshot.

## Verification

- `tsc --noEmit` on apps/website: pass
- Rendered locally: chip in the header, `since 1.5.0` badge on the `nonce` row, gutter note on the password-managers page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
