### PR TITLE
docs: add inspect.software health badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The accessible, unstyled, fully featured one-time-password component for React.
 [![npm](https://img.shields.io/npm/v/input-otp?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/input-otp)
 [![downloads](https://img.shields.io/npm/dm/input-otp?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/input-otp)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/input-otp?style=flat&label=size&colorA=000000&colorB=000000)](https://bundlephobia.com/package/input-otp)
+[![inspect.software](https://raw.githubusercontent.com/inspect-software/badges/main/v1/g/guilhermerodz/input-otp.svg)](https://inspect.software/software/guilhermerodz/input-otp)
 [![license](https://img.shields.io/npm/l/input-otp?style=flat&colorA=000000&colorB=000000)](./LICENSE)
 
 [**Documentation**](https://input-otp.rodz.dev/docs) · [Examples](https://input-otp.rodz.dev/docs/examples) · [API](https://input-otp.rodz.dev/docs/api) · [Edge cases](https://input-otp.rodz.dev/docs/edge-cases)


### PR DESCRIPTION
This PR adds the [inspect.software](https://inspect.software) health badge to the README.

**Why this PR?**
Your project ranks in the upper rating bands of our open-source health index (which measures maintainability, responsiveness, and security). This badge makes that standing objectively visible to your users. Our index is a free public good, and scores cannot be bought.

**Technical details:**
- **No tracking:** Static SVG served via GitHub's CDN. No JavaScript, no third-party tracking.
- **No maintenance:** The badge updates automatically after every inspection.
- **Transparent:** Links directly to [your full report](https://inspect.software/software/guilhermerodz/input-otp), based on our open [methodology](https://inspect.software/methodology).

If you prefer to keep your README minimal, feel free to close this PR without replying. Your report will remain publicly available and up-to-date either way.
